### PR TITLE
ref(*): update k3d image name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,8 +72,8 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/examples/k3d:${{ env.RELEASE_VERSION }}
-            ghcr.io/${{ github.repository }}/examples/k3d:latest
+            ghcr.io/${{ github.repository }}/k3d:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ github.repository }}/k3d:latest
           context: deployments/k3d
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/containerd-shim-spin/quickstart.md
+++ b/containerd-shim-spin/quickstart.md
@@ -14,7 +14,7 @@ Before you begin, you need to have the following installed:
 Start a k3d cluster with the wasm shims already installed:
 
 ```bash
-k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/examples/k3d:v0.10.0 -p "8081:80@loadbalancer" --agents 2 --registry-create mycluster-registry:12345
+k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.10.0 -p "8081:80@loadbalancer" --agents 2 --registry-create mycluster-registry:12345
 ```
 
 Apply RuntimeClass for spin applications to use the spin wasm shim:

--- a/deployments/k3d/README.md
+++ b/deployments/k3d/README.md
@@ -17,7 +17,7 @@ $ tree .
 ## How to run the example
 The shell script below will create a k3d cluster locally with the Wasm shims installed and containerd configured. The script then applies the runtime classes for the shims and an example service and deployment. Finally, we curl the `/hello` and receive a response from the example workload.
 ```shell
-k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/examples/k3d:v0.10.0 -p "8081:80@loadbalancer" --agents 2
+k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.10.0 -p "8081:80@loadbalancer" --agents 2
 kubectl apply -f https://github.com/spinkube/containerd-shim-spin/raw/main/deployments/workloads/runtime.yaml
 kubectl apply -f https://github.com/spinkube/containerd-shim-spin/raw/main/deployments/workloads/workload.yaml
 echo "waiting 5 seconds for workload to be ready"

--- a/images/spin-dapr/README.md
+++ b/images/spin-dapr/README.md
@@ -18,7 +18,7 @@ sudo mv ./spin /usr/local/bin/
 ### Run example with K3d:
 ```sh
 # start the K3d cluster
-k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/examples/k3d:v0.10.0 -p "8081:80@loadbalancer"
+k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.10.0 -p "8081:80@loadbalancer"
 # Install Dapr
 dapr init -k --wait
 # or via helm


### PR DESCRIPTION
We'd like to drop the `examples/` bit from the k3d image name

TODO:
- [x] full image name update depends on https://github.com/spinkube/containerd-shim-spin/pull/2; will rebase after it is merged.

Also note: CI/CD is still pending so the updated image references do not exist as of writing