### PR TITLE
fix(tests): address rustfmt err

### DIFF
--- a/tests/src/integration_test.rs
+++ b/tests/src/integration_test.rs
@@ -3,7 +3,7 @@ mod test {
     use redis::AsyncCommands;
     use tokio::process::Command;
 
-    use crate::{random_payload, retry_get, retry_put};
+    use crate::retry_get;
     use anyhow::Result;
 
     const RETRY_TIMES: u32 = 5;


### PR DESCRIPTION
Fix for the `rustfmt` check.

Error seen recently in https://github.com/spinkube/containerd-shim-spin/actions/runs/7759094517/job/21162392082?pr=2)