### PR TITLE
fix(shutdown): handle termination for container 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,8 @@ dependencies = [
  "anyhow",
  "containerd-shim",
  "containerd-shim-wasm",
+ "ctrlc",
+ "futures",
  "log",
  "oci-spec",
  "openssl",

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -32,3 +32,6 @@ serde_json = "1.0"
 url = "2.3"
 anyhow = "1.0"
 oci-spec = { version = "0.6.3" }
+futures = "0.3"
+ctrlc = { version = "3.2", features = ["termination"] }
+


### PR DESCRIPTION
This commit handles incoming termination signal for tasks, ensuring
tasks are correctly terminated.

diff for this change: https://github.com/spinkube/containerd-shim-spin/commit/bf26bdb880054998d5bb416ba580d2c062978c18

ref #22 
ref https://github.com/spinkube/spin-operator/issues/40
ref https://github.com/deislabs/containerd-wasm-shims/issues/207

Signed-off-by: Radu Matei <radu@fermyon.com>
Co-authored-by: Rajat Jindal <rajatjindal83@gmail.com>