### PR TITLE
Enable loading static assets in Spin applications

### DIFF
--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -85,8 +85,6 @@ impl SpinEngine {
                                 .context("failed to create spin.json")?
                                 .write_all(&artifact.layer)
                                 .context("failed to write spin.json")?;
-                            let lockfile = std::str::from_utf8(&artifact.layer)?;
-                            log::info!("lockfile: {:?}", lockfile);
                         }
                         MediaType::Other(name)
                             if name == "application/vnd.wasm.content.layer.v1+wasm" =>


### PR DESCRIPTION
Enables loading static assets in Spin applications.
Specifically, this modifies the engine to check for the Spin static asset
media type and adds that layer to the Spin cache, used later by the loader.