### PR TITLE
Add initial CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These owners will be the default owners for everything in the repository. Unless a later match takes precedence, they
 # will be requested for review when someone opens a pull request.
-*  @Mossaka @kate-goldenring @jsturtevant @radu-matei
+*  @Mossaka @kate-goldenring @jsturtevant @radu-matei @devigned


### PR DESCRIPTION
This commit adds @Mossaka @kate-goldenring @jsturtevant @radu-matei @devigned as initial codeowners of the project.

ref https://github.com/spinkube/governance