### PR TITLE
ci(*): disable docker provenence

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -49,7 +49,7 @@ jobs:
           sudo systemctl restart docker
       
       - name: test
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         if: ${{ inputs.test }}
         with:
           context: ${{ matrix.image.context }}
@@ -57,9 +57,7 @@ jobs:
           tags: containerd-shim-spin/${{ matrix.image.imageName }}:test
           platforms: wasi/wasm
       - name: build and push
-        # we use v3 here because we can't push wasi/wasm images with v4
-        # see https://github.com/deislabs/containerd-wasm-shims/issues/154#issuecomment-1726030749
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         if: ${{ !inputs.test }}
         with:
           push: true
@@ -68,3 +66,4 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.image.imageName }}:latest
           context: ${{ matrix.image.context }}
           platforms: wasi/wasm
+          provenance: false


### PR DESCRIPTION
Mirrored PR: https://github.com/deislabs/containerd-wasm-shims/pull/212

This allows the CI to produce a single image manifest instead of an index.