### PR TITLE
add workload delete test and refactor signal handling in run_wasi function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,12 @@ pod-status-check:
 workloads:
 	./scripts/workloads.sh
 
+./PHONY: test-workloads-delete
+test-workloads-delete:
+	./scripts/workloads-delete.sh
+
 .PHONY: integration-tests
-integration-tests: check-bins move-bins up pod-status-check workloads
+integration-tests: check-bins move-bins up pod-status-check workloads test-workloads-delete
 	cargo test -p containerd-shim-spin-tests -- --nocapture
 
 .PHONY: tests/clean

--- a/scripts/workloads-delete.sh
+++ b/scripts/workloads-delete.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+## test that the workload pods can be terminated
+kubectl delete pod -l app=wasm-spin --timeout 10s
+kubectl delete pod -l app=spin-keyvalue --timeout 10s
+kubectl delete pod -l app=spin-outbound-redis --timeout 10s
+


### PR DESCRIPTION
This PR adds a simple test case to validate that the pod is deleted successfully in a timely manner.

This PR also moves the signal handling to `run_wasi` function to ensure the pod can be terminated successfully even if the pod was requested to be deleted before the `run_trigger` function had setup the signals. Without this, there was a race condition between setting up of signals and receiving the signal, causing consistent failure on CI with the newly added testcase (and inconsistent failure when running locally)