### PR TITLE
Support trigger command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "spin-trigger-http",
  "spin-trigger-redis",
  "tokio",
+ "trigger-command",
  "trigger-sqs",
  "url",
  "wasmtime",
@@ -7358,6 +7359,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d127780145176e2b5d16611cc25a900150e86e9fd79d3bde6ff3a37359c9cb5"
 dependencies = [
  "serde_json",
+]
+
+[[package]]
+name = "trigger-command"
+version = "0.1.0"
+source = "git+https://github.com/fermyon/spin-trigger-command?rev=af3cf1148573ab10e1e819b66cd920a04a789e50#af3cf1148573ab10e1e819b66cd920a04a789e50"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "openssl",
+ "serde",
+ "spin-app",
+ "spin-core",
+ "spin-trigger",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wasmtime-wasi",
 ]
 
 [[package]]

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -22,6 +22,7 @@ spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.2", featur
 spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "dbfc599560ab54e759bfa586fe7315848f00a7f6" }
+trigger-command = { git = "https://github.com/fermyon/spin-trigger-command" , rev = "af3cf1148573ab10e1e819b66cd920a04a789e50" }
 spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }


### PR DESCRIPTION
This commit allows Spin apps to be init containers, based on https://github.com/fermyon/spin-trigger-command: 

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: spin-test-init
spec:
  replicas: 1
  selector:
    matchLabels:
      app: spin-test
  template:
    metadata:
      labels:
        app: spin-test
    spec:
      runtimeClassName: wasmtime-spin-v2
      initContainers:
      - name: spin-init
        image: ttl.sh/spinkube-init:24h
        command: ["/"]
      containers:
      - name: spin-test
        image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0
        command: ["/"]
        ports:
        - containerPort: 80
```