### PR TITLE
chore(*): Bump Spin dependency to v2.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4343,8 +4343,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -4362,8 +4362,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mqtt"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "rumqttc",
@@ -4379,8 +4379,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4399,8 +4399,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -4418,8 +4418,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
@@ -6071,8 +6071,8 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6087,8 +6087,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -6112,8 +6112,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.200.0",
@@ -6124,8 +6124,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6147,8 +6147,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6161,8 +6161,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -6179,8 +6179,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -6194,8 +6194,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -6209,8 +6209,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
@@ -6223,8 +6223,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-sqlite"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -6237,8 +6237,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -6250,8 +6250,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -6268,8 +6268,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6306,8 +6306,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6320,8 +6320,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -6335,8 +6335,8 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6363,8 +6363,8 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -6378,8 +6378,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -6387,8 +6387,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6401,8 +6401,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6416,8 +6416,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6431,8 +6431,8 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -6450,8 +6450,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6471,7 +6471,7 @@ dependencies = [
  "serde_json",
  "spin-app",
  "spin-common",
- "spin-componentize 2.4.0",
+ "spin-componentize 2.4.2",
  "spin-core",
  "spin-expressions",
  "spin-key-value",
@@ -6500,8 +6500,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6539,8 +6539,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6559,8 +6559,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6578,8 +6578,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "wasmtime",
 ]
@@ -6754,8 +6754,8 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 
 [[package]]
 name = "tar"
@@ -6797,8 +6797,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "2.4.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+version = "2.4.2"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.2#340378ebe9e370dd471d72782fbebdff46bc430f"
 dependencies = [
  "atty",
  "once_cell",
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "trigger-sqs"
 version = "0.6.0"
-source = "git+https://github.com/radu-matei/spin-trigger-sqs?rev=8e173e5c7023415cd6b29d1f0a37296d2861d5a2#8e173e5c7023415cd6b29d1f0a37296d2861d5a2"
+source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=b51f7fdc2a1bc7184dd2a3a1c1720e1ebe2adba3#b51f7fdc2a1bc7184dd2a3a1c1720e1ebe2adba3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7371,6 +7371,7 @@ dependencies = [
  "clap",
  "futures",
  "is-terminal",
+ "openssl",
  "serde",
  "spin-core",
  "spin-trigger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,7 @@ dependencies = [
  "spin-common",
  "spin-componentize 0.1.0",
  "spin-core",
+ "spin-expressions",
  "spin-loader",
  "spin-manifest",
  "spin-oci",
@@ -2174,6 +2175,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,7 +2792,7 @@ dependencies = [
  "hyper 0.14.28",
  "log",
  "rustls 0.20.9",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.23.4",
  "webpki-roots 0.22.6",
@@ -2797,10 +2809,27 @@ dependencies = [
  "hyper 0.14.28",
  "log",
  "rustls 0.21.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
- "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "log",
+ "rustls 0.22.3",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -3400,10 +3429,11 @@ checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
 
 [[package]]
 name = "libsql"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43adbef635c87aaf72870e0a1a8cb39eefcc2c0b0386c75a9436ba6048548f07"
+checksum = "3879a4ed80a245fd4dd8c8fa139245653e86184ed3ab97a6d6ea592045d25793"
 dependencies = [
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "bitflags 2.5.0",
@@ -3412,14 +3442,28 @@ dependencies = [
  "futures",
  "http 0.2.12",
  "hyper 0.14.28",
- "hyper-rustls 0.24.2",
+ "hyper-rustls 0.25.0",
+ "libsql-hrana",
  "libsql-sqlite3-parser",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.10",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "libsql-hrana"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f256c5c98e84808e067133253471d6f5961c670f0127150694210fb8e6116a"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "prost 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -4146,6 +4190,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost 0.12.3",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.12.3",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float 4.2.0",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,6 +4287,15 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -4203,14 +4343,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 0.2.12",
  "reqwest",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-locked-app",
  "spin-outbound-networking",
  "spin-world",
@@ -4220,9 +4361,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "outbound-mqtt"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+dependencies = [
+ "anyhow",
+ "rumqttc",
+ "spin-app",
+ "spin-core",
+ "spin-expressions",
+ "spin-outbound-networking",
+ "spin-world",
+ "table",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "outbound-mysql"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4230,6 +4388,7 @@ dependencies = [
  "mysql_common",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -4240,14 +4399,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "native-tls",
  "postgres-native-tls",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -4258,13 +4418,14 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -5231,6 +5392,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.1",
+ "rustls-webpki 0.102.2",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "url",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5360,8 +5540,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5372,6 +5566,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -5395,12 +5602,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -5553,7 +5787,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -5831,11 +6065,14 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin-app"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5850,8 +6087,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -5875,8 +6112,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.200.0",
@@ -5887,8 +6124,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5898,6 +6135,7 @@ dependencies = [
  "crossbeam-channel",
  "io-extras",
  "rustix 0.37.27",
+ "spin-telemetry",
  "system-interface",
  "tokio",
  "tracing",
@@ -5908,9 +6146,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-expressions"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dotenvy",
+ "once_cell",
+ "serde",
+ "spin-locked-app",
+ "thiserror",
+]
+
+[[package]]
 name = "spin-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -5927,8 +6179,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -5942,8 +6194,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -5957,8 +6209,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
@@ -5971,8 +6223,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-sqlite"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -5985,8 +6237,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5998,8 +6250,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -6009,14 +6261,15 @@ dependencies = [
  "serde_json",
  "spin-core",
  "spin-llm",
+ "spin-telemetry",
  "spin-world",
  "tracing",
 ]
 
 [[package]]
 name = "spin-loader"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6053,8 +6306,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6067,8 +6320,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -6082,8 +6335,8 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6110,11 +6363,13 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
+ "http 1.1.0",
  "ipnet",
+ "spin-expressions",
  "spin-locked-app",
  "terminal",
  "url",
@@ -6123,8 +6378,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -6132,8 +6387,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6146,8 +6401,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6161,8 +6416,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6175,9 +6430,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-telemetry"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
+dependencies = [
+ "anyhow",
+ "http 0.2.12",
+ "http 1.1.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "spin-trigger"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6188,6 +6462,7 @@ dependencies = [
  "indexmap 1.9.3",
  "ipnet",
  "outbound-http",
+ "outbound-mqtt",
  "outbound-mysql",
  "outbound-pg",
  "outbound-redis",
@@ -6196,8 +6471,9 @@ dependencies = [
  "serde_json",
  "spin-app",
  "spin-common",
- "spin-componentize 2.3.1",
+ "spin-componentize 2.4.0",
  "spin-core",
+ "spin-expressions",
  "spin-key-value",
  "spin-key-value-azure",
  "spin-key-value-redis",
@@ -6224,8 +6500,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6246,6 +6522,7 @@ dependencies = [
  "spin-core",
  "spin-http",
  "spin-outbound-networking",
+ "spin-telemetry",
  "spin-trigger",
  "spin-world",
  "terminal",
@@ -6262,8 +6539,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6271,16 +6548,19 @@ dependencies = [
  "redis 0.21.7",
  "serde",
  "spin-app",
+ "spin-common",
  "spin-core",
+ "spin-expressions",
  "spin-trigger",
  "spin-world",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "spin-variables"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6289,6 +6569,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-world",
  "thiserror",
  "tokio",
@@ -6297,8 +6578,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "wasmtime",
 ]
@@ -6473,8 +6754,8 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 
 [[package]]
 name = "tar"
@@ -6516,8 +6797,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "atty",
  "once_cell",
@@ -6658,9 +6939,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6750,6 +7031,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -6966,6 +7258,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6998,6 +7302,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7007,12 +7339,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -7027,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "trigger-sqs"
 version = "0.6.0"
-source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=ad7c5405d588161ce4ac317172dd8b165bdab572#ad7c5405d588161ce4ac317172dd8b165bdab572"
+source = "git+https://github.com/radu-matei/spin-trigger-sqs?rev=8e173e5c7023415cd6b29d1f0a37296d2861d5a2#8e173e5c7023415cd6b29d1f0a37296d2861d5a2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7980,6 +8315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8003,6 +8348,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "trigger-sqs"
 version = "0.6.0"
-source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=b51f7fdc2a1bc7184dd2a3a1c1720e1ebe2adba3#b51f7fdc2a1bc7184dd2a3a1c1720e1ebe2adba3"
+source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=dbfc599560ab54e759bfa586fe7315848f00a7f6#dbfc599560ab54e759bfa586fe7315848f00a7f6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -21,7 +21,7 @@ spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev 
 spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.2", features = ["unsafe-aot-compilation"] }
 spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "b51f7fdc2a1bc7184dd2a3a1c1720e1ebe2adba3" }
+trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "dbfc599560ab54e759bfa586fe7315848f00a7f6" }
 spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -14,20 +14,19 @@ Containerd shim for running Spin workloads.
 containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", rev = "c04170e81794b1a776c840ffa765b3491d43445a" }
 containerd-shim = "0.7.1"
 log = "0.4"
-spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "191789170abde10cd55590466c0660dd6c7d472a" }
 # Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.0", features = ["unsafe-aot-compilation"] }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
-spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
-# TODO: change to the original repo once https://github.com/fermyon/spin-trigger-sqs/pull/19 is merged.
-trigger-sqs = { git = "https://github.com/radu-matei/spin-trigger-sqs", rev = "8e173e5c7023415cd6b29d1f0a37296d2861d5a2" }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
-spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
-spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
-spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.2", features = ["unsafe-aot-compilation"] }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "b51f7fdc2a1bc7184dd2a3a1c1720e1ebe2adba3" }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
 wasmtime = "18.0.1"
 tokio = { version = "1.37", features = ["rt"] }
 openssl = { version = "*", features = ["vendored"] }

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -14,20 +14,22 @@ Containerd shim for running Spin workloads.
 containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", rev = "c04170e81794b1a776c840ffa765b3491d43445a" }
 containerd-shim = "0.7.1"
 log = "0.4"
-spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
+spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
 spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "191789170abde10cd55590466c0660dd6c7d472a" }
 # Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.3.1", features = ["unsafe-aot-compilation"] }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "ad7c5405d588161ce4ac317172dd8b165bdab572" }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.0", features = ["unsafe-aot-compilation"] }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+# TODO: change to the original repo once https://github.com/fermyon/spin-trigger-sqs/pull/19 is merged.
+trigger-sqs = { git = "https://github.com/radu-matei/spin-trigger-sqs", rev = "8e173e5c7023415cd6b29d1f0a37296d2861d5a2" }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
 wasmtime = "18.0.1"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1.37", features = ["rt"] }
 openssl = { version = "*", features = ["vendored"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -58,7 +58,12 @@ impl Default for SpinEngine {
 
 struct StdioTriggerHook;
 impl TriggerHooks for StdioTriggerHook {
-    fn app_loaded(&mut self, _app: &spin_app::App, _runtime_config: &RuntimeConfig) -> Result<()> {
+    fn app_loaded(
+        &mut self,
+        _app: &spin_app::App,
+        _runtime_config: &RuntimeConfig,
+        _resolver: &std::sync::Arc<spin_expressions::PreparedResolver>,
+    ) -> Result<()> {
         Ok(())
     }
 


### PR DESCRIPTION
close #54 

This commit updates the Spin dependency to v2.4.0.

Draft until https://github.com/fermyon/spin-trigger-sqs/pull/19 is merged.