### PR TITLE
allow ci to collect logs on failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,19 @@ jobs:
         working-directory: ./deployments/k3d
       - name: run integration tests
         run: BIN_DIR="./bin" make integration-tests
+
+      - name: run collect debug logs
+        if: failure()
+        run: make tests/collect-debug-logs
+ 
+      - name: upload debug logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: debug-logs
+          path: debug-logs/
+          retention-days: 5
+
       - name: clean up k3d
         if: always()
         run: make tests/clean

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ test-workloads-delete:
 integration-tests: check-bins move-bins up pod-status-check workloads test-workloads-delete
 	cargo test -p containerd-shim-spin-tests -- --nocapture
 
+.PHONY: tests/collect-debug-logs
+tests/collect-debug-logs:
+	./scripts/collect-debug-logs.sh 2>&1
+
 .PHONY: tests/clean
 tests/clean:
 	./scripts/down.sh

--- a/scripts/collect-debug-logs.sh
+++ b/scripts/collect-debug-logs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+echo "collecting debug info from CI run in 'debug-logs' dir"
+
+mkdir -p debug-logs
+
+echo "-> k3d cluster list" > debug-logs/kubernetes.log
+k3d cluster list >> debug-logs/kubernetes.log
+echo "" >> debug-logs/kubernetes.log
+
+echo "-> kubectl get pods -n default -o wide" >> debug-logs/kubernetes.log
+kubectl get pods -n default -o wide >> debug-logs/kubernetes.log
+echo "" >> debug-logs/kubernetes.log
+
+echo "-> kubectl describe pods -n default" >> debug-logs/kubernetes.log
+kubectl describe pods -n default >> debug-logs/kubernetes.log
+echo "" >> debug-logs/kubernetes.log
+
+for node in `k3d node list --no-headers | awk '{print $1}'`; do
+	echo "collecting containerd logs from $node"
+	docker cp $node:/var/lib/rancher/k3s/agent/containerd/containerd.log debug-logs/$node.containerd.log || echo "containerd.log file not found in $node"
+done


### PR DESCRIPTION
on failure, it will be nice to collect some debug logs that can help in debugging further. e.g. I am trying to [debug this failure](https://github.com/spinkube/containerd-shim-spin/actions/runs/8456341091/job/23166936399#step:8:861)

I saw that we collect some info in `workloads.sh`, but that won't be collected if the script fails before that.