### PR TITLE
refactor: move deps to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/spinkube/containerd-shim-spin"
-homepage = "https://github.com/spinkube/containerd-shim-spin"
+homepage = "https://spinkube.dev/docs/containerd-shim-spin/"
+authors = ["SpinKube Engineering Team"]
 
 
 [workspace]
@@ -13,3 +14,41 @@ members = [
     "tests",
     "containerd-shim-spin"
 ]
+
+[workspace.dependencies]
+containerd-shim-wasm = "0.5.0"
+containerd-shim = "0.7.1"
+log = "0.4"
+spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "191789170abde10cd55590466c0660dd6c7d472a" }
+# Enable loading components precompiled by the shim
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.2", features = ["unsafe-aot-compilation"] }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "dbfc599560ab54e759bfa586fe7315848f00a7f6" }
+trigger-command = { git = "https://github.com/fermyon/spin-trigger-command" , rev = "af3cf1148573ab10e1e819b66cd920a04a789e50" }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
+wasmtime = "18.0.1"
+tokio = { version = "1.37", features = ["rt", "macros", "process"] }
+openssl = { version = "*", features = ["vendored"] }
+serde = "1.0"
+serde_json = "1.0"
+url = "2.3"
+anyhow = "1.0"
+oci-spec = { version = "0.6.3" }
+futures = "0.3"
+ctrlc = { version = "3.2", features = ["termination"] }
+kube = { version = "0.87", features = ["runtime", "derive", "ws"] }
+k8s-openapi = { version = "0.20", features = ["v1_25"] }
+curl = { version = "0.4", features = ["static-curl"]}
+rand = "0.8"
+wat = "1.0"
+http = "0.2"
+tower = "0.4"
+hyper = "0.14"
+redis = { version = "0.23", features = ["tokio-comp"] }

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -1,44 +1,43 @@
 [package]
 name = "containerd-shim-spin-v2"
-version = "0.13.1"
-authors = ["SpinKube Engineering Team"]
-edition = "2021"
-repository = 'https://github.com/spinkube/containerd-shim-spin'
-license = "Apache-2.0"
-homepage = 'https://github.com/spinkube/containerd-shim-spin'
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+homepage.workspace = true
 description = """
 Containerd shim for running Spin workloads.
 """
 
 [dependencies]
-containerd-shim-wasm = "0.5.0"
-containerd-shim = "0.7.1"
-log = "0.4"
-spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "191789170abde10cd55590466c0660dd6c7d472a" }
-# Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.2", features = ["unsafe-aot-compilation"] }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "dbfc599560ab54e759bfa586fe7315848f00a7f6" }
-trigger-command = { git = "https://github.com/fermyon/spin-trigger-command" , rev = "af3cf1148573ab10e1e819b66cd920a04a789e50" }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v2.4.2" }
-wasmtime = "18.0.1"
-tokio = { version = "1.37", features = ["rt"] }
-openssl = { version = "*", features = ["vendored"] }
-serde = "1.0"
-serde_json = "1.0"
-url = "2.3"
-anyhow = "1.0"
-oci-spec = { version = "0.6.3" }
-futures = "0.3"
-ctrlc = { version = "3.2", features = ["termination"] }
+containerd-shim-wasm = { workspace = true }
+containerd-shim = { workspace = true }
+log = { workspace = true }
+spin-app = { workspace = true }
+spin-core = { workspace = true }
+spin-componentize = { workspace = true }
+spin-trigger = { workspace = true }
+spin-trigger-http = { workspace = true }
+spin-trigger-redis = { workspace = true }
+trigger-sqs = { workspace = true }
+trigger-command = { workspace = true }
+spin-manifest = { workspace = true }
+spin-loader = { workspace = true }
+spin-oci = { workspace = true }
+spin-common = { workspace = true }
+spin-expressions = { workspace = true }
+wasmtime = { workspace = true }
+tokio = { workspace = true }
+openssl = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }
+anyhow = { workspace = true }
+oci-spec = { workspace = true }
+futures = { workspace = true }
+ctrlc = { workspace = true }
 
 
 [dev-dependencies]
-wat = "1"
+wat = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -3,20 +3,23 @@ name = "containerd-shim-spin-tests"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
-kube = { version = "0.87", features = ["runtime", "derive", "ws"] }
-k8s-openapi = { version = "0.20", features = ["v1_25"] }
-curl = { version = "0.4", features = ["static-curl"]}
-rand = "0.8"
-tokio = { version = "1", features = ["rt", "macros", "process"] }
+anyhow = { workspace = true }
+kube = { workspace = true }
+k8s-openapi = { workspace = true }
+curl = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true }
 
 
 [dev-dependencies]
-http = "0.2"
-tower = "0.4"
-hyper = "0.14"
-redis = { version = "0.23", features = ["tokio-comp"] }
+http = { workspace = true }
+tower = { workspace = true }
+hyper = { workspace = true }
+redis = { workspace = true }


### PR DESCRIPTION
helps to manage versions of deps across multiple crates in the workspace.