### PR TITLE
update download/upload artifact action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
           cd _dist
           tar czf containerd-shim-spin-${{ matrix.shims.version }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz containerd-shim-spin-${{ matrix.shims.version }}
       - name: upload shim artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: containerd-shim-spin-${{ matrix.shims.version }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/containerd-shim-spin-${{ matrix.shims.version }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       ARCH: x86_64
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - uses: azure/setup-kubectl@v4
       - name: "Install dependencies"
         run: |
@@ -65,7 +65,7 @@ jobs:
  
       - name: upload debug logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debug-logs
           path: debug-logs/

--- a/.github/workflows/node-installer.yaml
+++ b/.github/workflows/node-installer.yaml
@@ -27,7 +27,7 @@ jobs:
             echo "RELEASE_VERSION=$(date +%Y%m%d-%H%M%S)-g$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           fi
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: _artifacts
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
             echo "RELEASE_VERSION=$(date +%Y%m%d-%H%M%S)-g$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           fi
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: _artifacts
 


### PR DESCRIPTION
The dependabot PR's are most likely failing because they are two separate PR's to update download/upload artifact action, and they are incompatible with each other.

This PR updates both of them in one go.