### PR TITLE
feat(images): update spin-inbound-redis to use variable interpolation for address

### DIFF
--- a/images/spin-inbound-redis/spin.toml
+++ b/images/spin-inbound-redis/spin.toml
@@ -10,7 +10,7 @@ redis_address = { required = true }
 redis_channel = { required = true }
 
 [[trigger.redis]]
-address = "redis://redis-service.default.svc.cluster.local:6379"
+address = "{{ redis_address }}"
 component = "hello"
 
 [component.hello]


### PR DESCRIPTION
As of Spin [v2.4.0](https://github.com/fermyon/spin/releases/tag/v2.4.0), variable interpolation can be used for the redis trigger address.  It looks like the spin crates in the shim are at v2.4.2 as of writing, so it seems appropriate to update the example to use this feature.