### PR TITLE
add basic version command to shim

### DIFF
--- a/containerd-shim-spin/src/main.rs
+++ b/containerd-shim-spin/src/main.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use containerd_shim::Config;
 use containerd_shim_wasm::{
     container::Instance,
@@ -5,8 +7,15 @@ use containerd_shim_wasm::{
 };
 
 mod engine;
+mod version;
 
 fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() > 1 && args[1] == "--version" {
+        version::print_version();
+        return;
+    }
+
     // Configure the shim to have only error level logging for performance improvements.
     let shim_config = Config {
         default_log_level: "error".to_string(),

--- a/containerd-shim-spin/src/version.rs
+++ b/containerd-shim-spin/src/version.rs
@@ -1,0 +1,5 @@
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn print_version() {
+    println!("{}", VERSION);
+}


### PR DESCRIPTION
this could be useful info when debugging the shim issues. we should probably also add git-info to this. but that could be a separate PR.