### PR TITLE
ci(dependabot): ignore wasmtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "wasmtime"


### PR DESCRIPTION
this commit asks dependboto to ignore updates to wasmtime crate since it has to be done together with updates to Spin, which at the moment is done manually