### PR TITLE
Integrate spin_telemetry to support OTel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
+dependencies = [
+ "async-channel 2.2.0",
+ "async-io 2.3.2",
+ "async-lock 3.3.0",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener 5.3.0",
+ "futures-lite 2.3.0",
+ "rustix 0.38.32",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "async-signal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,7 +300,7 @@ dependencies = [
  "async-global-executor",
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "async-process",
+ "async-process 1.8.1",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -724,11 +744,38 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "rustc_version",
  "serde",
  "serde_json",
  "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.13",
+ "http-types",
+ "once_cell",
+ "paste",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.4",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -740,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73dede39a91e205b2050f250f6e31ed7c4c72be7ee694930c155c4d7636fe8e1"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.11.0",
  "bytes",
  "futures",
  "hmac",
@@ -752,6 +799,41 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c97790480791ec1ee9b76f5c6499b1d0aac0d4cd1e62010bfc19bb545544c5"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-process 2.2.2",
+ "async-trait",
+ "azure_core 0.20.0",
+ "futures",
+ "oauth2",
+ "pin-project",
+ "serde",
+ "time",
+ "tracing",
+ "tz-rs",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_security_keyvault"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338cac645bda0555f59189873be0cccaf420c26791f009b2207b62474cebbab8"
+dependencies = [
+ "async-trait",
+ "azure_core 0.20.0",
+ "futures",
+ "serde",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -964,7 +1046,7 @@ dependencies = [
  "indicatif",
  "log",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "sha2",
@@ -1241,6 +1323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1424,7 @@ dependencies = [
  "spin-loader",
  "spin-manifest",
  "spin-oci",
+ "spin-telemetry",
  "spin-trigger",
  "spin-trigger-http",
  "spin-trigger-redis",
@@ -1418,18 +1507,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d5521e2abca66bbb1ddeecbb6f6965c79160352ae1579b39f8c86183895c24"
+checksum = "496c993b62bdfbe9b4c518b8b3e1fdba9f89ef89fcccc050ab61d91dfba9fbaf"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef40a4338a47506e832ac3e53f7f1375bc59351f049a8379ff736dd02565bd95"
+checksum = "96b922abb6be41fc383f5e9da65b58d32d0d0a32c87dfe3bbbcb61a09119506c"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1448,33 +1537,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24cd5d85985c070f73dfca07521d09086362d1590105ba44b0932bf33513b61"
+checksum = "634c2ed9ef8a04ca42535a3e2e7917e4b551f2f306f4df2d935a6e71e346c167"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0584c4363e3aa0a3c7cb98a778fbd5326a3709f117849a727da081d4051726c"
+checksum = "00cde1425b4da28bb0d5ff010030ea9cc9be7aded342ae099b394284f17cefce"
 
 [[package]]
 name = "cranelift-control"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25ecede098c6553fdba362a8e4c9ecb8d40138363bff47f9712db75be7f0571"
+checksum = "1622125c99f1864aaf44e57971770c4a918d081d4b4af0bb597bdf624660ed66"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea081a42f25dc4c5b248b87efdd87dcd3842a1050a37524ec5391e6172058cb"
+checksum = "ea97887aca1c0cbe7f8513874dc3603e9744fb1cfa78840ca8897bd2766bd35b"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1482,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9796e712f5af797e247784f7518e6b0a83a8907d73d51526982d86ecb3a58b68"
+checksum = "4cdade4c14183fe41482071ed77d6a38cb95a17c7a0a05e629152e6292c4f8cb"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1494,15 +1583,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a66ccad5782f15c80e9dd5af0df4acfe6e3eee98e8f7354a2e5c8ec3104bdd"
+checksum = "dbbe4d3ad7bd4bf4a8d916c8460b441cf92417f5cdeacce4dd1d96eee70b18a2"
 
 [[package]]
 name = "cranelift-native"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285e80df1d9b79ded9775b285df68b920a277b84f88a7228d2f5bc31fcdc58eb"
+checksum = "c46be4ed1fc8f36df4e2a442b8c30a39d8c03c1868182978f4c04ba2c25c9d4f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1511,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.105.3"
+version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4135b0ab01fd16aa8f8821196e9e2fe15953552ccaef8ba5153be0ced04ef757"
+checksum = "a1d4c4a785a7866da89d20df159e3c4f96a5f14feb83b1f5998cfd5fe2e74d06"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1954,7 +2043,7 @@ dependencies = [
  "mime",
  "pin-project",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -2872,12 +2961,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -2885,6 +2991,9 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3022,17 +3131,6 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "itertools"
@@ -4058,6 +4156,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.13",
+ "http 0.2.12",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4071,19 +4188,19 @@ dependencies = [
 
 [[package]]
 name = "oci-distribution"
-version = "0.10.0"
-source = "git+https://github.com/fermyon/oci-distribution?rev=63cbb0925775e0c9c870195cad1d50ac8707a264#63cbb0925775e0c9c870195cad1d50ac8707a264"
+version = "0.11.0"
+source = "git+https://github.com/fermyon/oci-distribution?rev=7e4ce9be9bcd22e78a28f06204931f10c44402ba#7e4ce9be9bcd22e78a28f06204931f10c44402ba"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http 0.2.12",
+ "http 1.1.0",
  "http-auth",
  "jwt",
  "lazy_static",
  "olpc-cjson",
  "regex",
- "reqwest",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "sha2",
@@ -4224,7 +4341,7 @@ dependencies = [
  "bytes",
  "http 0.2.12",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.11.27",
 ]
 
 [[package]]
@@ -4242,8 +4359,10 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost 0.12.4",
- "reqwest",
+ "reqwest 0.11.27",
  "thiserror",
+ "tokio",
+ "tonic",
 ]
 
 [[package]]
@@ -4353,17 +4472,18 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "http 0.2.12",
- "reqwest",
+ "reqwest 0.11.27",
  "spin-app",
  "spin-core",
  "spin-expressions",
  "spin-locked-app",
  "spin-outbound-networking",
+ "spin-telemetry",
  "spin-world",
  "terminal",
  "tracing",
@@ -4372,8 +4492,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mqtt"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "rumqttc",
@@ -4389,8 +4509,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4409,8 +4529,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -4428,8 +4548,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
@@ -5335,7 +5455,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -5362,7 +5482,48 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util 0.7.10",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -5400,6 +5561,16 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "routefinder"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0971d3c8943a6267d6bd0d782fdc4afa7593e7381a92a3df950ff58897e066b5"
+dependencies = [
+ "smartcow",
+ "smartstring",
+]
 
 [[package]]
 name = "rumqttc"
@@ -5477,7 +5648,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 0.2.12",
- "reqwest",
+ "reqwest 0.11.27",
  "rustify_derive",
  "serde",
  "serde_json",
@@ -5853,6 +6024,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6036,6 +6217,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smartcow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656fcb1c1fca8c4655372134ce87d8afdf5ec5949ebabe8d314be0141d8b5da2"
+dependencies = [
+ "smartstring",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6081,8 +6282,8 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6097,8 +6298,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -6110,8 +6311,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.200.0",
@@ -6122,8 +6323,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6145,8 +6346,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6159,8 +6360,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -6168,6 +6369,7 @@ dependencies = [
  "hyper 1.2.0",
  "indexmap 1.9.3",
  "percent-encoding",
+ "routefinder",
  "serde",
  "spin-app",
  "spin-locked-app",
@@ -6177,8 +6379,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -6192,8 +6394,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -6202,13 +6404,14 @@ dependencies = [
  "spin-core",
  "spin-key-value",
  "tokio",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "spin-key-value-redis"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
@@ -6216,13 +6419,14 @@ dependencies = [
  "spin-key-value",
  "spin-world",
  "tokio",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "spin-key-value-sqlite"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -6231,12 +6435,13 @@ dependencies = [
  "spin-key-value",
  "spin-world",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "spin-llm"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -6248,13 +6453,13 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "http 0.2.12",
  "llm",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "spin-core",
@@ -6266,8 +6471,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6282,7 +6487,7 @@ dependencies = [
  "outbound-http",
  "path-absolutize",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_json",
@@ -6304,8 +6509,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6318,8 +6523,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -6333,8 +6538,8 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6344,8 +6549,9 @@ dependencies = [
  "dkregistry",
  "docker_credential",
  "futures-util",
+ "itertools 0.12.1",
  "oci-distribution",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "spin-common",
@@ -6361,8 +6567,8 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -6376,8 +6582,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -6385,8 +6591,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6395,12 +6601,13 @@ dependencies = [
  "spin-world",
  "table",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6410,12 +6617,13 @@ dependencies = [
  "spin-sqlite",
  "spin-world",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6425,12 +6633,13 @@ dependencies = [
  "spin-world",
  "sqlparser",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "spin-telemetry"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -6439,6 +6648,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "terminal",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -6448,8 +6658,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6498,8 +6708,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6537,8 +6747,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6549,6 +6759,7 @@ dependencies = [
  "spin-common",
  "spin-core",
  "spin-expressions",
+ "spin-telemetry",
  "spin-trigger",
  "spin-world",
  "tokio",
@@ -6557,11 +6768,14 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "anyhow",
  "async-trait",
+ "azure_core 0.20.0",
+ "azure_identity",
+ "azure_security_keyvault",
  "dotenvy",
  "once_cell",
  "serde",
@@ -6571,13 +6785,14 @@ dependencies = [
  "spin-world",
  "thiserror",
  "tokio",
+ "tracing",
  "vaultrs",
 ]
 
 [[package]]
 name = "spin-world"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "wasmtime",
 ]
@@ -6752,8 +6967,8 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 
 [[package]]
 name = "tar"
@@ -6795,8 +7010,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "2.4.3"
-source = "git+https://github.com/fermyon/spin?tag=v2.4.3#ed8a665fb92e23402f8c321573d353b84f8c29aa"
+version = "2.5.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.5.1#cba6773845e6160cc1804d2037be5b5e33f3226a"
 dependencies = [
  "atty",
  "once_cell",
@@ -6847,6 +7062,7 @@ checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -6889,16 +7105,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls-listener"
-version = "0.4.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8a215badde081a06ee0a7fbc9c9f0d580c022fbdc547065f62103aef71e178"
+checksum = "ce110c38c3c9b6e5cc4fe72e60feb5b327750388a10a276e3d5d7d431e3dc76c"
 dependencies = [
  "futures-util",
- "hyper 0.14.28",
  "pin-project-lite",
  "thiserror",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.25.0",
 ]
 
 [[package]]
@@ -6925,7 +7140,7 @@ dependencies = [
  "rayon-cond",
  "regex",
  "regex-syntax 0.7.5",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "spm_precompiled",
@@ -7289,17 +7504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-opentelemetry"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7312,7 +7516,6 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -7344,7 +7547,6 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 
@@ -7360,7 +7562,7 @@ dependencies = [
 [[package]]
 name = "trigger-command"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-trigger-command?rev=cc09ed61c5cd04de507b62a6f4912d8ae026bff6#cc09ed61c5cd04de507b62a6f4912d8ae026bff6"
+source = "git+https://github.com/fermyon/spin-trigger-command?rev=27131158f19c4791bf019c29a0522638b37c5ba0#27131158f19c4791bf019c29a0522638b37c5ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7369,17 +7571,17 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-core",
+ "spin-telemetry",
  "spin-trigger",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "wasmtime-wasi",
 ]
 
 [[package]]
 name = "trigger-sqs"
 version = "0.6.0"
-source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=ee1195ad76b78c41f9d8291e3470bcb0e8c01e66#ee1195ad76b78c41f9d8291e3470bcb0e8c01e66"
+source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=b0230d1de5c14141d1f1c8bfa90f2ae538cfe44d#b0230d1de5c14141d1f1c8bfa90f2ae538cfe44d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7387,15 +7589,14 @@ dependencies = [
  "aws-sdk-sqs",
  "clap",
  "futures",
- "is-terminal",
  "openssl",
  "serde",
  "spin-core",
+ "spin-telemetry",
  "spin-trigger",
  "tokio",
  "tokio-scoped",
  "tracing",
- "tracing-subscriber",
  "wasmtime",
 ]
 
@@ -7484,6 +7685,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -7636,7 +7846,7 @@ dependencies = [
  "bytes",
  "derive_builder 0.11.2",
  "http 0.2.12",
- "reqwest",
+ "reqwest 0.11.27",
  "rustify",
  "rustify_derive",
  "serde",
@@ -7697,9 +7907,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e022c29ad56af4cc0a8a8f0e0191abf9e0a0c4a68d25dfe088c39c9a8e3d2c"
+checksum = "5ce5d3e7e6f0fabe518a9bea9c803081544ef38d986f04d7f86737faed32d2ae"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -7895,9 +8105,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8106d7d22d63d1bcb940e22dcc7b03e46f0fc8bfbaf2fd7b6cb8f448f9449774"
+checksum = "69472708b96ee90579a482bdbb908ce97e53a9e5ebbcab59cc29c3977bcab512"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -7939,18 +8149,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0cf02cea951ace34ee3b0e64b7f446c3519d1c95ad75bc5330f405e275ee8f"
+checksum = "86292d6a9bf30c669582a40c4a4b8e0b8640e951f3635ee8e0acf7f87809961e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3249204a71d728d53fb3eea18afd0473f87e520445707a4d567ac4da0bb3eb5d"
+checksum = "8a180017db1233c902b992fea9484640d265f2fedf03db60eed57894cb2effcc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -7968,9 +8178,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3786c0531565ec6c9852c0e46299f06cb6e4b58d36e30f3c234cfa69bde376"
+checksum = "dc6aca484581f9651886dca45f9dea893e105713b58623d14b06c56d8fe3f3f1"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7983,15 +8193,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81eae2ec98027ee0b3950da83bc320120a23087ac4d39b3d59201cb5ebf52777"
+checksum = "0aa907cc97ad039c43f98525d772f4841c2ce69a0c11eeec2a3a9c77fc730e87"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595abdb067acdc812ab0f21d8d46d5aa4022392aa7c3e0632c20bff9ec49ffb4"
+checksum = "b57d58e220ae223855c5d030ef20753377bc716d0c81b34c1fe74c9f44268774"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -8014,9 +8224,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c24c1fdea167b992d82ebe76471fd1cbe7b0b406bc72f9250f86353000134e"
+checksum = "1ba2cfdfdbde42f0f3baeddb62f3555524dee9f836c96da8d466e299f75f5eee"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8030,9 +8240,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3279d510005358141550d8a90a5fc989d7e81748e5759d582fe6bfdcbf074a04"
+checksum = "abbf3075d9ee7eb1263dc67949aced64d0f0bf27be8098d34d8e5826cf0ff0f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8056,9 +8266,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1df665f2117741d1265f5663b0d93068b18120c2c4b18b9faed49d00d92c31"
+checksum = "3174f71c8fbd9d2cb1233ad9f912f106bdd2a1a6d11a1b7707974ba3ad5f304a"
 dependencies = [
  "anyhow",
  "cc",
@@ -8071,9 +8281,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f307739370736e5b0cd2b45910ff96bcda6d5d68b2c4384bcedb0af4f3b321"
+checksum = "4b0462a46b80d2352ee553b17d626b6468e9cec2220cc58ac31754fd7b58245e"
 dependencies = [
  "object",
  "once_cell",
@@ -8083,9 +8293,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866634605089b4632b32226b54aa3670d72e1849f9fc425c7e50b3749c2e6df3"
+checksum = "dacd2aa30fb20fd8cd0eb4e664024a1ab28a02958529fa05bf52117532a098fc"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -8094,9 +8304,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11185c88cadf595d228f5ae4ff9b4badbf9ca98dcb37b0310c36e31fa74867f"
+checksum = "d14e97c4bb36d91bcdd194745446d595e67ce8b89916806270fdbee640c747fd"
 dependencies = [
  "anyhow",
  "cc",
@@ -8124,9 +8334,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32377cbd827bee06fcb2f6bf97b0477fdcc86888bbe6db7b9cab8e644082e0a"
+checksum = "530b94c627a454d24f520173d3145112d1b807c44c82697a57e1d8e28390cde4"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -8137,9 +8347,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab8d7566d206c42f8cf1d4ac90c5e40d3582e8eabad9b3b67e9e73c61fc47a1"
+checksum = "5399c175ddba4a471b9da45105dea3493059d52b2d54860eadb0df04c813948d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8148,9 +8358,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca912bda309188bd25ab7652c6654b34aacdf43047c716ee1cb685a28079078"
+checksum = "aa0c9371a5270bc5e043f4eff80c572bc35585ab68d0a218d0ec3d3225085347"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8181,9 +8391,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbe5ffc98df206cdd791af8d3048d5e5d12376c995cb1e7348ad77023235264"
+checksum = "b87c2a334ceb4a9b4899bc5661e0be5f1f800d76a700044cae5d5397ad5c9717"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8204,9 +8414,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a97bfccc241d1769cef75eb16f472a893982704d5f3c9c71c431c1484344a"
+checksum = "729dff119cfd2e2333504b52db6661e49278314c83276a01d15a2a86e566e614"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8221,9 +8431,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf2c76781a27e07802669f6f0e11eb4441546407eb65be60c3d862200988b92"
+checksum = "6945fc6cfee04ba81016e9723bea77a2b913108e03904a4d901daedf208365f5"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -8233,9 +8443,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3847d969bd203b8cd239f89581e52432a0f00b8c5c9bc917be2fccd7542c4f2f"
+checksum = "e1711f429111e782fac0537e0b3eb2ab6f821613cf1ec3013f2a0ff3fde41745"
 
 [[package]]
 name = "wast"
@@ -8347,9 +8557,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7ecd6e1ffba1278cfd24a001a13da11d86801e0ad9342f11a370ce0df50e14"
+checksum = "186f82e079c09d2b7215ecaeacc97cac09631522016ba500ccc788749e882439"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8362,9 +8572,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5490497a35d67040d4f2fd2491fbcad6dd225c5bd24681c2cd52a2f40a55ce"
+checksum = "def372d639555c826c4f287a7bdde673da127ecb95a3cd5453d53d8f3c0c07e4"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -8377,9 +8587,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "18.0.3"
+version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f31d1c1a0d87842f1a2bf40bd230e25ba790c450f0d0ddb84524fd6955958"
+checksum = "93e43fc332703d1ec3aa86a5ce8bb49e6b95b6c617b90e726d3e70a0f70f48a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8420,9 +8630,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0bd4d6cac8d69525d475d0ce1e0801eb6f314d42e764a52bd497ed3cb9c371"
+checksum = "433cafb378ad01cd839974846204f56257ec34fc9d7db309ce1e34f24923fa6a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8589,6 +8799,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",

--- a/containerd-shim-spin/Cargo.lock
+++ b/containerd-shim-spin/Cargo.lock
@@ -6497,11 +6497,7 @@ dependencies = [
 [[package]]
 name = "trigger-sqs"
 version = "0.5.0"
-<<<<<<< Updated upstream
-source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=f60545012bc153071d8005d1b8ed117a614dce0b#f60545012bc153071d8005d1b8ed117a614dce0b"
-=======
 source = "git+https://github.com/fermyon/spin-trigger-sqs?rev=34ef90888a7374ca53d32654dcf02b3fbfd82119#34ef90888a7374ca53d32654dcf02b3fbfd82119"
->>>>>>> Stashed changes
 dependencies = [
  "anyhow",
  "async-trait",

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -14,21 +14,22 @@ Containerd shim for running Spin workloads.
 containerd-shim-wasm = "0.5.0"
 containerd-shim = "0.7.1"
 log = "0.4"
-spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-spin-componentize = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
+spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-componentize = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
 # Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.3", features = ["unsafe-aot-compilation"] }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "ee1195ad76b78c41f9d8291e3470bcb0e8c01e66" }
-trigger-command = { git = "https://github.com/fermyon/spin-trigger-command" , rev = "cc09ed61c5cd04de507b62a6f4912d8ae026bff6" }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v2.4.3" }
-wasmtime = "18.0.1"
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.5.1", features = ["unsafe-aot-compilation"] }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "b0230d1de5c14141d1f1c8bfa90f2ae538cfe44d" }
+trigger-command = { git = "https://github.com/fermyon/spin-trigger-command", rev = "27131158f19c4791bf019c29a0522638b37c5ba0" }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+spin-telemetry = { git = "https://github.com/fermyon/spin", tag = "v2.5.1" }
+wasmtime = "18.0.4"
 tokio = { version = "1.37", features = ["rt"] }
 openssl = { version = "*", features = ["vendored"] }
 serde = "1.0"
@@ -38,7 +39,6 @@ anyhow = "1.0"
 oci-spec = { version = "0.6.3" }
 futures = "0.3"
 ctrlc = { version = "3.2", features = ["termination"] }
-
 
 [dev-dependencies]
 wat = "1"

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, ensure, Context, Result};
 use containerd_shim_wasm::{
     container::{Engine, RuntimeContext, Stdio},
     sandbox::WasmLayer,
+    version,
 };
 use futures::future;
 use log::info;
@@ -193,6 +194,9 @@ impl SpinEngine {
         let trigger_cmds = trigger_command_for_resolved_app_source(&resolved_app_source)
             .with_context(|| format!("Couldn't find trigger executor for {app_source:?}"))?;
         let locked_app = self.load_resolved_app_source(resolved_app_source).await?;
+
+        let _telemetry_guard = spin_telemetry::init(version!().to_string())?;
+
         self.run_trigger(
             ctx,
             trigger_cmds.iter().map(|s| s.as_ref()).collect(),


### PR DESCRIPTION
Integrates `spin_telemetry` into the shim so that we get OTel support.

The workaround to prevent the panic is to point at versions of spin and spin triggers that don't use the [`tracing-log`](https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/#optional-dependencies) feature.