### PR TITLE
Make container environment variables accessible as application variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,7 @@ dependencies = [
  "spin-trigger",
  "spin-trigger-http",
  "spin-trigger-redis",
+ "temp-env",
  "tokio",
  "trigger-command",
  "trigger-sqs",
@@ -8001,6 +8002,15 @@ name = "temp-dir"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -42,3 +42,4 @@ ctrlc = { version = "3.2", features = ["termination"] }
 
 [dev-dependencies]
 wat = "1"
+temp-env = "0.3.6"

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -43,8 +43,8 @@ const OCI_LAYER_MEDIA_TYPE_WASM: &str = "application/vnd.wasm.content.layer.v1+w
 /// Expected location of the Spin manifest when loading from a file rather than
 /// an OCI image
 const SPIN_MANIFEST_FILE_PATH: &str = "/spin.toml";
-/// Known prefix for the Spin application variables environment variables
-/// provider.
+/// Known prefix for the Spin application variables environment variable
+/// provider: https://github.com/fermyon/spin/blob/436ad589237c02f7aa4693e984132808fd80b863/crates/variables/src/provider/env.rs#L9
 const SPIN_APPLICATION_VARIABLE_PREFIX: &str = "SPIN_VARIABLE";
 
 #[derive(Clone)]
@@ -406,12 +406,14 @@ impl SpinEngine {
 }
 
 // For each container environment variable, duplicates it in the environment
-// with a given prefix
+// with a given prefix unless already prefixed
 fn prefix_env_vars(prefix: &str) {
-    std::env::vars().for_each(|(var, val)| {
-        let prefixed = format!("{}{}", prefix, var);
-        std::env::set_var(prefixed, val);
-    });
+    std::env::vars()
+        .filter(|(var, _)| !var.starts_with(prefix))
+        .for_each(|(var, val)| {
+            let prefixed = format!("{}_{}", prefix, var);
+            std::env::set_var(prefixed, val);
+        });
 }
 
 impl Engine for SpinEngine {
@@ -552,7 +554,21 @@ fn trigger_command_for_resolved_app_source(resolved: &ResolvedAppSource) -> Resu
 
 #[cfg(test)]
 mod tests {
+    use std::env;
+
     use super::*;
+
+    #[test]
+    fn test_prefix_env_vars() {
+        let prefix = "FOO";
+        env::set_var("FOO_DO_NOT_RESET", "val1");
+        env::set_var("SHOULD_BE_PREFIXED", "val2");
+        prefix_env_vars(prefix);
+        assert_eq!(env::var("FOO_DO_NOT_RESET").unwrap(), "val1");
+        assert_eq!(env::var("FOO_SHOULD_BE_PREFIXED").unwrap(), "val2");
+        // Original env vars are still retained but not set in variable provider
+        assert!(env::var("SHOULD_BE_PREFIXED").is_ok());
+    }
 
     #[test]
     fn can_parse_spin_address() {

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -43,18 +43,9 @@ const OCI_LAYER_MEDIA_TYPE_WASM: &str = "application/vnd.wasm.content.layer.v1+w
 /// Expected location of the Spin manifest when loading from a file rather than
 /// an OCI image
 const SPIN_MANIFEST_FILE_PATH: &str = "/spin.toml";
-/// Prefix for Spin runtime environment variables This prefix indicates that the
-/// environment variable should not be set in a component's environment and
-/// should instead be reinjected into the shim's environment without the prefix.
-/// The environment variable with the prefix will be retained in the shim's
-/// environment.
-const SPIN_RUNTIME_ENV_VAR_PREFIX: &str = "SPIN_";
 /// Known prefix for the Spin application variables environment variables
 /// provider.
 const SPIN_APPLICATION_VARIABLE_PREFIX: &str = "SPIN_VARIABLE";
-/// When set, ensures that the shim does not set any container environment
-/// variables in the Spin application.
-const SPIN_DISABLE_CONTAINER_ENV_INJECTION_ENV: &str = "SPIN_NO_CONTAINER_ENV_INJECTION";
 
 #[derive(Clone)]
 pub struct SpinEngine {
@@ -206,7 +197,11 @@ impl SpinEngine {
     }
 
     async fn wasm_exec_async(&self, ctx: &impl RuntimeContext) -> Result<()> {
-        let app_env_vars = get_app_env_vars();
+        // Create a duplicate of the environment variables with the application
+        // variables environment variable provider default prefix. This makes
+        // container environment variables accessible to Spin application
+        // components that explicitly allow them in the Spin manifest.
+        prefix_env_vars(SPIN_APPLICATION_VARIABLE_PREFIX);
         // create a cache directory at /.cache
         // this is needed for the spin LocalLoader to work
         // TODO: spin should provide a more flexible `loader::from_file` that
@@ -220,10 +215,7 @@ impl SpinEngine {
         let resolved_app_source = self.resolve_app_source(app_source.clone(), &cache).await?;
         let trigger_cmds = trigger_command_for_resolved_app_source(&resolved_app_source)
             .with_context(|| format!("Couldn't find trigger executor for {app_source:?}"))?;
-        let mut locked_app = self.load_resolved_app_source(resolved_app_source).await?;
-        if env::var(SPIN_DISABLE_CONTAINER_ENV_INJECTION_ENV).is_err() {
-            set_env_vars_in_locked_app(&mut locked_app, app_env_vars);
-        }
+        let locked_app = self.load_resolved_app_source(resolved_app_source).await?;
 
         let _telemetry_guard = spin_telemetry::init(version!().to_string())?;
 
@@ -413,55 +405,13 @@ impl SpinEngine {
     }
 }
 
-// Parses the container environment variables to filter out the Spin runtime
-// environment variables. The Spin runtime environment variables are then reset
-// in the environment without their prefix to ensure they can be used by
-// triggers and telemetry sources.
-//
-// Note: Environment variables with both the Spin runtime prefix and a known K8s
-// container env suffix will be retained in the app environment variable list.
-// This is to account for the scenario where a cluster service name starts with
-// "spin".
-//
-// Returns the Spin application environment variables.
-fn get_app_env_vars() -> Vec<(String, String)> {
-    let (runtime_envs, app_envs): (_, Vec<_>) = std::env::vars().partition(|(var, _)| {
-        var.starts_with(SPIN_RUNTIME_ENV_VAR_PREFIX)
-            && !known_k8s_env_var_suffixes()
-                .iter()
-                .any(|suffix| var.ends_with(suffix))
+// For each container environment variable, duplicates it in the environment
+// with a given prefix
+fn prefix_env_vars(prefix: &str) {
+    std::env::vars().for_each(|(var, val)| {
+        let prefixed = format!("{}{}", prefix, var);
+        std::env::set_var(prefixed, val);
     });
-    // Reset Spin runtime envionment variables without the runtime prefix
-    runtime_envs
-        .iter()
-        .filter(|(var, _)| !var.starts_with(SPIN_APPLICATION_VARIABLE_PREFIX))
-        .for_each(|(var, val)| {
-            std::env::set_var(&var[5..], val);
-        });
-    app_envs
-}
-
-// Returns a list of known K8s environment variable suffixes that are used to
-// identify environment variables that should be retained in the app environment
-// variable list.
-// See https://kubernetes.io/docs/concepts/containers/container-environment/#container-environment
-fn known_k8s_env_var_suffixes() -> Vec<&'static str> {
-    vec![
-        "SERVICE_PORT",
-        "SERVICE_HOST",
-        "PORT",
-        "HOST",
-        "TCP_ADDR",
-        "TCP",
-        "PROTO",
-    ]
-}
-
-// Sets environment variables in every component of a Spin application
-fn set_env_vars_in_locked_app(locked_app: &mut LockedApp, envs: Vec<(String, String)>) {
-    for component in locked_app.components.iter_mut() {
-        component.env.extend(envs.iter().cloned());
-    }
 }
 
 impl Engine for SpinEngine {

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -197,11 +197,6 @@ impl SpinEngine {
     }
 
     async fn wasm_exec_async(&self, ctx: &impl RuntimeContext) -> Result<()> {
-        // Create a duplicate of the environment variables with the application
-        // variables environment variable provider default prefix. This makes
-        // container environment variables accessible to Spin application
-        // components that explicitly allow them in the Spin manifest.
-        prefix_env_vars(SPIN_APPLICATION_VARIABLE_PREFIX);
         // create a cache directory at /.cache
         // this is needed for the spin LocalLoader to work
         // TODO: spin should provide a more flexible `loader::from_file` that
@@ -213,6 +208,7 @@ impl SpinEngine {
         env::set_var("XDG_CACHE_HOME", &cache_dir);
         let app_source = self.app_source(ctx, &cache).await?;
         let resolved_app_source = self.resolve_app_source(app_source.clone(), &cache).await?;
+        configure_application_variables_from_environment_variables(&resolved_app_source)?;
         let trigger_cmds = trigger_command_for_resolved_app_source(&resolved_app_source)
             .with_context(|| format!("Couldn't find trigger executor for {app_source:?}"))?;
         let locked_app = self.load_resolved_app_source(resolved_app_source).await?;
@@ -405,17 +401,6 @@ impl SpinEngine {
     }
 }
 
-// For each container environment variable, duplicates it in the environment
-// with a given prefix unless already prefixed
-fn prefix_env_vars(prefix: &str) {
-    std::env::vars()
-        .filter(|(var, _)| !var.starts_with(prefix))
-        .for_each(|(var, val)| {
-            let prefixed = format!("{}_{}", prefix, var);
-            std::env::set_var(prefixed, val);
-        });
-}
-
 impl Engine for SpinEngine {
     fn name() -> &'static str {
         "spin"
@@ -532,6 +517,21 @@ impl ResolvedAppSource {
         ensure!(!types.is_empty(), "no triggers in app");
         Ok(types.into_iter().map(|t| t.as_str()).collect())
     }
+
+    pub fn variables(&self) -> Vec<&str> {
+        match self {
+            ResolvedAppSource::File { manifest, .. } => manifest
+                .variables
+                .keys()
+                .map(|k| k.as_ref())
+                .collect::<Vec<_>>(),
+            ResolvedAppSource::OciRegistry { locked_app } => locked_app
+                .variables
+                .keys()
+                .map(|k| k.as_ref())
+                .collect::<Vec<_>>(),
+        }
+    }
 }
 
 fn trigger_command_for_resolved_app_source(resolved: &ResolvedAppSource) -> Result<Vec<String>> {
@@ -552,6 +552,27 @@ fn trigger_command_for_resolved_app_source(resolved: &ResolvedAppSource) -> Resu
     Ok(trigger_types.iter().map(|x| x.to_string()).collect())
 }
 
+// For each Spin app variable, checks if a container environment variable with
+// the same name exists and duplicates it in the environment with the
+// application variable prefix
+fn configure_application_variables_from_environment_variables(
+    resolved: &ResolvedAppSource,
+) -> Result<()> {
+    resolved
+        .variables()
+        .into_iter()
+        .map(str::to_ascii_uppercase)
+        .for_each(|variable| {
+            env::var(&variable)
+                .map(|val| {
+                    let prefixed = format!("{}_{}", SPIN_APPLICATION_VARIABLE_PREFIX, variable);
+                    env::set_var(prefixed, val);
+                })
+                .ok();
+        });
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;
@@ -559,15 +580,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_prefix_env_vars() {
-        let prefix = "FOO";
-        env::set_var("FOO_DO_NOT_RESET", "val1");
-        env::set_var("SHOULD_BE_PREFIXED", "val2");
-        prefix_env_vars(prefix);
-        assert_eq!(env::var("FOO_DO_NOT_RESET").unwrap(), "val1");
-        assert_eq!(env::var("FOO_SHOULD_BE_PREFIXED").unwrap(), "val2");
-        // Original env vars are still retained but not set in variable provider
-        assert!(env::var("SHOULD_BE_PREFIXED").is_ok());
+    fn test_configure_application_variables_from_environment_variables() {
+        temp_env::with_vars(
+            [
+                ("SPIN_VARIABLE_DO_NOT_RESET", Some("val1")),
+                ("SHOULD_BE_PREFIXED", Some("val2")),
+                ("ignored_if_not_uppercased_env", Some("val3")),
+            ],
+            || {
+                let app_json = r#"
+                {
+                    "spin_lock_version": 1,
+                    "entrypoint": "test",
+                    "components": [],
+                    "variables": {"should_be_prefixed": { "required": "true"},  "do_not_reset" : { "required": "true"}, "not_set_as_container_env": { "required": "true"}, "ignored_if_not_uppercased_env": { "required": "true"}},
+                    "triggers": []
+                }"#;
+                let locked_app = LockedApp::from_json(app_json.as_bytes()).unwrap();
+                let resolved = ResolvedAppSource::OciRegistry { locked_app };
+
+                configure_application_variables_from_environment_variables(&resolved).unwrap();
+                assert_eq!(env::var("SPIN_VARIABLE_DO_NOT_RESET").unwrap(), "val1");
+                assert_eq!(
+                    env::var("SPIN_VARIABLE_SHOULD_BE_PREFIXED").unwrap(),
+                    "val2"
+                );
+                assert!(env::var("SPIN_VARIABLE_NOT_SET_AS_CONTAINER_ENV").is_err());
+                assert!(env::var("SPIN_VARIABLE_IGNORED_IF_NOT_UPPERCASED_ENV").is_err());
+                // Original env vars are still retained but not set in variable provider
+                assert!(env::var("SHOULD_BE_PREFIXED").is_ok());
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
Prefixes all container env vars with `SPIN_VARIABLE`. This means that Spin components can get access to these variables if specifically configured in the Spin manifest to have access. For example, say a a component wants access to the `KUBERNETES_SERVICE_ADDRESS` container environment variable, it would configure this in the Spin.toml as follows:

```sh
[variables]
kubernetes_service_address = { required = true }

[component.example]
source = "target/wasm32-wasi/release/example.wasm"
allowed_outbound_hosts = []
[component.example.variables]
kubernetes_service_address = "{{ kubernetes_service_address }}"
```

Then, it can be accessed in the Spin app using the variables SDK:
```rust
let addr = variables::get("kubernetes_service_address")?;
```

Should affect/reflect the "Configuring Runtime Options" SKIP https://github.com/spinkube/skips/pull/4