### PR TITLE
fix(node-installer): avoid false positive via grep process itself

### DIFF
--- a/node-installer/script/installer.sh
+++ b/node-installer/script/installer.sh
@@ -11,7 +11,7 @@ IS_MICROK8S=false
 IS_K3S=false
 IS_RKE2_AGENT=false
 IS_K0S_WORKER=false
-if ps aux | grep kubelet | grep -q snap/microk8s; then
+if pgrep -f snap/microk8s > /dev/null; then
     CONTAINERD_CONF=/var/snap/microk8s/current/args/containerd-template.toml
     IS_MICROK8S=true
     if nsenter -m/$NODE_ROOT/proc/1/ns/mnt -- ls /var/snap/microk8s/current/args/containerd-template.toml > /dev/null 2>&1 ;then
@@ -28,7 +28,7 @@ elif ls $NODE_ROOT/var/lib/rancher/k3s/agent/etc/containerd/config.toml > /dev/n
     IS_K3S=true
     cp $NODE_ROOT/var/lib/rancher/k3s/agent/etc/containerd/config.toml $NODE_ROOT/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
     CONTAINERD_CONF=/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
-elif ps aux | grep kubelet | grep -q /var/lib/k0s/bin/kubelet; then
+elif pgrep -f /var/lib/k0s/bin/kubelet > /dev/null; then
     IS_K0S_WORKER=true
     CONTAINERD_CONF=/etc/k0s/containerd.d/spin.toml
     touch $NODE_ROOT$CONTAINERD_CONF


### PR DESCRIPTION
I was testing with the latest v0.15.0 node-installer image and stumbled upon the following issue.

My K8s cluster happened to be a [KinD cluster](https://kind.sigs.k8s.io/) and yet the node-installer script thought I was using k0s and thus failed like so:

```
$ k -n kwasm logs pod/kind-worker2-provision-kwasm-724lt
touch: /mnt/node-root/etc/k0s/containerd.d/spin.toml: No such file or directory
```

It turns out that the current logic [here](https://github.com/spinkube/containerd-shim-spin/blob/main/node-installer/script/installer.sh#L31) will exit 0 because the latter `grep` process itself is successfully found -- whereas it should not be counted.

For example, on my kind-worker node:
```
root@kind-worker:/# ps aux | grep kubelet | grep /var/lib/k0s/bin/kubelet
root        1820  0.0  0.0   3076  1280 pts/1    S+   21:13   0:00 grep /var/lib/k0s/bin/kubelet
root@kind-worker:/# echo $?
0
```

There are a couple ways to fix this.  In this first iteration, I've elected to use [pgrep](https://man7.org/linux/man-pages/man1/pgrep.1.html) which won't report its own process as an eligible result.  ~~However, I'm not 100% certain that this binary is present in all of the supported distros...~~ (pgrep exists in the node-installer image, so we are good there)

Another option would be to tweak the logic to add an additional `grep -v grep` at the end of the pipe, eg `ps aux | grep kubelet | grep /var/lib/k0s/bin/kubelet | grep -vq grep`.  Happy to go with this approach if preferred.

---
PS I'm still not totally sure why the similar [microk8s detection method](https://github.com/spinkube/containerd-shim-spin/blob/main/node-installer/script/installer.sh#L14) doesn't also produce a false positive.  eg on my kind-worker, it exits 1 as expected:

```
root@kind-worker:/# ps aux | grep kubelet | grep -q snap/microk8s
root@kind-worker:/# echo $?
1
```