### PR TITLE
Add MQTT trigger and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,7 @@ dependencies = [
  "kube",
  "rand 0.8.5",
  "redis 0.25.4",
+ "rumqttc",
  "tokio",
  "tower",
 ]
@@ -1659,6 +1660,7 @@ dependencies = [
  "temp-env",
  "tokio",
  "trigger-command",
+ "trigger-mqtt",
  "trigger-sqs",
  "url",
  "wasmtime",
@@ -2801,6 +2803,12 @@ name = "futures-task"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -5268,6 +5276,32 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "paho-mqtt"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8367868d51cef74c28da328ed8f60529ddd3f04dca1867dd825fcc3085a4308"
+dependencies = [
+ "async-channel 1.9.0",
+ "crossbeam-channel",
+ "futures",
+ "futures-timer",
+ "libc",
+ "log",
+ "paho-mqtt-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "paho-mqtt-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e482419d847af4ec43c07eed70f5f94f87dc712d267aecc91ab940944ab6bf4"
+dependencies = [
+ "cmake",
+ "openssl-sys",
 ]
 
 [[package]]
@@ -8655,6 +8689,25 @@ dependencies = [
  "tokio",
  "tracing",
  "wasmtime-wasi",
+]
+
+[[package]]
+name = "trigger-mqtt"
+version = "0.2.0"
+source = "git+https://github.com/kate-goldenring/spin-trigger-mqtt?branch=use-spin-telemetry#4814a09d13bf559079da726c86f710b469cb47d0"
+dependencies = [
+ "anyhow",
+ "clap 3.2.25",
+ "futures",
+ "paho-mqtt",
+ "serde 1.0.204",
+ "spin-app",
+ "spin-core",
+ "spin-expressions",
+ "spin-telemetry",
+ "spin-trigger",
+ "tokio",
+ "wasmtime",
 ]
 
 [[package]]

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -21,6 +21,7 @@ spin-componentize = { git = "https://github.com/fermyon/spin", tag = "v2.6.0" }
 spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.6.0", features = ["unsafe-aot-compilation"] }
 spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v2.6.0" }
 spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v2.6.0" }
+trigger-mqtt = { git = "https://github.com/kate-goldenring/spin-trigger-mqtt", branch = "use-spin-telemetry" }
 trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", rev = "v0.7.0" }
 trigger-command = { git = "https://github.com/fermyon/spin-trigger-command", tag = "v0.1.0" }
 spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.6.0" }

--- a/images/spin-mqtt-message-logger/.gitignore
+++ b/images/spin-mqtt-message-logger/.gitignore
@@ -1,0 +1,2 @@
+target/
+.spin/

--- a/images/spin-mqtt-message-logger/Cargo.toml
+++ b/images/spin-mqtt-message-logger/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mqtt-message-logger"
+authors = ["Kate Goldenring <kate.goldenring@fermyon.com>"]
+description = "Triggered by MQTT"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1"
+chrono =  "0.4"
+spin-mqtt-sdk = { git = "https://github.com/spinkube/spin-trigger-mqtt" }

--- a/images/spin-mqtt-message-logger/README
+++ b/images/spin-mqtt-message-logger/README
@@ -1,0 +1,60 @@
+# MQTT Message Logger Spin App
+
+Spin listens to an MQTT broker at a specific topic. It executes the Spin app for each newly published message. The Spin app simply logs the message.
+
+## Running an MQTT broker
+
+Download [MQTTX CLI](https://github.com/emqx/MQTTX/tree/main/cli)
+
+```sh
+brew install emqx/mqttx/mqttx-cli
+```
+
+Run the EMQX broker: https://mqttx.app/docs/get-started
+
+```sh
+docker run -d --name emqx -p 1883:1883 -p 8083:8083 -p 8883:8883 -p 8084:8084 -p 18083:18083 emqx/emqx
+```
+
+Connect to locally running broker
+
+```sh
+mqttx conn -h '127.0.0.1' -p 1883
+```
+
+Subscribe to the hello topic
+
+```sh
+mqttx sub -t 'hello' -h '127.0.0.1' -p 1883
+```
+
+Publish to the hello topic
+
+```sh
+mqttx pub -t 'hello' -h '127.0.0.1' -p 1883 -m 'from me'
+```
+
+
+## Running the spin app to listen to a specific topic
+
+```sh
+SPIN_VARIABLE_MQTT_TOPIC="hello" SPIN_VARIABLE_MQTT_BROKER_URI="mqtt://localhost:1883" spin build --up 
+```
+
+Or use the pushed app:
+
+```sh
+SPIN_VARIABLE_MQTT_TOPIC="hello" SPIN_VARIABLE_MQTT_BROKER_URI="mqtt://localhost:1883" spin up --from ghcr.io/kate-goldenring/mqtt-message-logger:v1
+```
+
+Now publish a message to the hello topic:
+
+```sh
+mqttx pub -t 'hello' -h '127.0.0.1' -p 1883 -m 'from me'
+```
+
+The following should be logged in the `spin build --up` output:
+
+```sh
+"2024-06-07 20:21:32.265317000" Message received by wasm component: 'from me' on topic 'hello'
+```

--- a/images/spin-mqtt-message-logger/spin.toml
+++ b/images/spin-mqtt-message-logger/spin.toml
@@ -1,0 +1,29 @@
+spin_manifest_version = 2
+
+[application]
+name = "mqtt-message-logger"
+version = "0.1.0"
+authors = ["Kate Goldenring <kate.goldenring@fermyon.com>"]
+description = "Triggered by MQTT"
+
+[variables]
+mqtt_topic = { required = true }
+mqtt_broker_uri = { required = true }
+
+[application.trigger.mqtt]
+address = "{{ mqtt_broker_uri }}"
+username = ""
+password = ""
+keep_alive_interval = "30"
+
+[[trigger.mqtt]]
+component = "mqtt-message-logger"
+topic = "{{ mqtt_topic }}"
+qos = "1"
+
+[component.mqtt-message-logger]
+source = "target/wasm32-wasi/release/mqtt_message_logger.wasm"
+allowed_outbound_hosts = []
+[component.mqtt-message-logger.build]
+command = "cargo build --target wasm32-wasi --release"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/images/spin-mqtt-message-logger/src/lib.rs
+++ b/images/spin-mqtt-message-logger/src/lib.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Utc};
+use spin_mqtt_sdk::{mqtt_component, Metadata, Payload};
+
+#[mqtt_component]
+async fn handle_message(message: Payload, metadata: Metadata) -> anyhow::Result<()> {
+    let datetime: DateTime<Utc> = std::time::SystemTime::now().into();
+    let formatted_time = datetime.format("%Y-%m-%d %H:%M:%S.%f").to_string();
+
+    println!(
+        "{:?} Message received by wasm component: '{}' on topic '{}'",
+        formatted_time,
+        String::from_utf8_lossy(&message),
+        metadata.topic
+    );
+    Ok(())
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,3 +20,4 @@ http = "1.1"
 tower = "0.4"
 hyper = "1.4"
 redis = { version = "0.25", features = ["tokio-comp"] }
+rumqttc = "0.24.0"

--- a/tests/src/integration_test.rs
+++ b/tests/src/integration_test.rs
@@ -129,6 +129,60 @@ mod test {
     }
 
     #[tokio::test]
+    async fn spin_mqtt_trigger_app_test() -> Result<()> {
+        use std::time::Duration;
+        let mqtt_port = 1883;
+        let message = "MESSAGE";
+        let iterations = 5;
+
+        // Ensure kubectl is in PATH
+        if !is_kubectl_installed().await? {
+            anyhow::bail!("kubectl is not installed");
+        }
+
+        // Port forward the emqx mqtt broker
+        let forward_port = port_forward_emqx(mqtt_port).await?;
+
+        // Publish a message to the emqx broker
+        let mut mqttoptions = rumqttc::MqttOptions::new("123", "127.0.0.1", forward_port);
+        mqttoptions.set_keep_alive(std::time::Duration::from_secs(1));
+
+        let (client, mut eventloop) = rumqttc::AsyncClient::new(mqttoptions, 10);
+        client
+            .subscribe("hello", rumqttc::QoS::AtMostOnce)
+            .await
+            .unwrap();
+
+        // Publish a message several times for redundancy
+        tokio::task::spawn(async move {
+            for _i in 0..iterations {
+                client
+                    .publish(
+                        "hello",
+                        rumqttc::QoS::AtLeastOnce,
+                        false,
+                        message.as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        });
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        // Poll the event loop to ensure messages are published
+        for _i in 0..iterations {
+            eventloop.poll().await?;
+        }
+        thread::sleep(time::Duration::from_secs(5));
+
+        // Ensure that the message was received and logged by the spin app
+        let log = get_logs_by_label("app=spin-mqtt-message-logger").await?;
+        assert!(log.contains(message));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn spin_static_assets_test() -> Result<()> {
         let host_port = 8082;
 
@@ -176,6 +230,32 @@ mod test {
             .spawn()?;
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
         Ok(port)
+    }
+
+    async fn port_forward_emqx(emqx_port: u16) -> Result<u16> {
+        let port = get_random_port()?;
+
+        println!(" >>> kubectl portforward emqx {}:{} ", port, emqx_port);
+
+        Command::new("kubectl")
+            .arg("port-forward")
+            .arg("emqx")
+            .arg(format!("{}:{}", port, emqx_port))
+            .spawn()?;
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        Ok(port)
+    }
+
+    async fn get_logs_by_label(label: &str) -> Result<String> {
+        let output = Command::new("kubectl")
+            .arg("logs")
+            .arg("-l")
+            .arg(label)
+            .output()
+            .await
+            .context("failed to get logs")?;
+        let log = std::str::from_utf8(&output.stdout)?;
+        Ok(log.to_owned())
     }
 
     /// Uses a track to get a random unused port

--- a/tests/workloads-common/mqtt-broker.yaml
+++ b/tests/workloads-common/mqtt-broker.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: emqx
+  labels:
+    app: emqx
+spec:
+  containers:
+  - name: emqx
+    image: emqx/emqx
+    ports:
+    - containerPort: 1883
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emqx
+spec:
+  selector:
+    app: emqx
+  ports:
+  - protocol: TCP
+    port: 1883
+    targetPort: 1883
+  type: ClusterIP  

--- a/tests/workloads-pushed-using-spin-registry-push/workloads.yaml
+++ b/tests/workloads-pushed-using-spin-registry-push/workloads.yaml
@@ -254,3 +254,43 @@ spec:
       targetPort: 80
   selector:
     app: spin-static-assets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spin-mqtt-message-logger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spin-mqtt-message-logger
+  template:
+    metadata:
+      labels:
+        app: spin-mqtt-message-logger
+    spec:
+      runtimeClassName: wasmtime-spin
+      containers:
+        - name: spin-mqtt-message-logger
+          image: test-registry:5000/spin-registry-push/spin-mqtt-message-logger:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/"]
+          ports:
+          - containerPort: 80
+          env:
+          - name: SPIN_VARIABLE_MQTT_TOPIC
+            value: hello
+          - name: SPIN_VARIABLE_MQTT_BROKER_URI
+            value: "mqtt://emqx.default.svc.cluster.local:1883"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spin-mqtt-message-logger
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app: spin-mqtt-message-logger


### PR DESCRIPTION
closes https://github.com/spinkube/containerd-shim-spin/issues/111

This should be merged first and then ideally a release of the trigger cut: https://github.com/spinkube/spin-trigger-mqtt/pull/29

Adds an MQTT test which contains a deployment for an MQTT broker and a spin app that is triggered by the the broker.