### PR TITLE
readme & setup: simplify the run command and fix an error in setup-linux.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ make setup # setup linux environment
 Build, install, and run the shim binary:
 
 ```bash
-make run-spin # run the shim binary
+make run # run the shim binary
 ```
 
 You may open another terminal and run the following command to test the shim:

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -3,10 +3,11 @@ sudo apt -y update
 sudo apt-get install -y protobuf-compiler libseccomp-dev
 
 echo "setting up rust"
-sudo rustup toolchain install --component clippy --component rustfmt --no-self-update
+sudo rustup toolchain install --component clippy --component rustfmt --no-self-update stable
 sudo rustup target add wasm32-wasi && sudo rustup target add wasm32-unknown-unknown
 
 ## setup tinygo. required for building test spin app
 echo "setting up tinygo"
 wget https://github.com/tinygo-org/tinygo/releases/download/v0.30.0/tinygo_0.30.0_amd64.deb
 sudo dpkg -i tinygo_0.30.0_amd64.deb
+rm tinygo_0.30.0_amd64.deb


### PR DESCRIPTION
1. change `make run-spin` to `make run`
2. fix an error encountered in setup-linux.sh
