### PR TITLE
Require Rust version 1.79 or above

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-wasi", "wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
This is necessary because Spin now requires this version of Rust. 