### PR TITLE
fix(docs): update CHANGELOG.md formatting for v0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.16.0 - 2024-10-04
+## [v0.16.0](https://github.com/spinkube/containerd-shim-spin/releases/tag/v0.16.0) - 2024-10-04
 
 ### Added
 


### PR DESCRIPTION
The `extract-changelog.sh` script expects the released version to be declared in `CHANGELOG.md` in the following format:
1. Following a subheader definition (`##`)
2. Inside brackets -- I assume this is to link to the release as I've done here

Note, whether or not it is a pre-release is now expected to be in the tag name according to the release workflow. When creating releases, I normally modify the release afterwards to say that it is a prerelease. I hesitate to add `-pre` to the end of our tags when we have not been doing that previously and i think of anything less than semver `1.0.0` to be pre-release