### PR TITLE
fix(release): update release workflow to make changelog available

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,19 +47,18 @@ jobs:
           mkdir -p _dist
           cp ./deployments/workloads/runtime.yaml _dist/runtime.yaml
           cp ./deployments/workloads/workload.yaml _dist/workload.yaml
-      
-      - name: extract changelog
-        run: |
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-          cd $GITHUB_WORKSPACE
-          ./scripts/extract-changelog.sh $TAG_NAME > RELEASE_NOTES.md
-          cat RELEASE_NOTES.md
   
       - name: create release
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Extract changelog
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          cd $GITHUB_WORKSPACE
+          ./scripts/extract-changelog.sh $TAG_NAME > RELEASE_NOTES.md
+          cat RELEASE_NOTES.md
+
           TAG_NAME=${GITHUB_REF#refs/tags/}
           if [[ "$TAG_NAME" =~ .+-pre.* ]]; then
             PRERELEASE_ARGS="--prerelease --latest=false"


### PR DESCRIPTION
I believe that the `create release` step is currently failing due to lack of access to the `RELEASE_NOTES.md` file created in the previous step.

Alternative approach would be to upload and then download the `RELEASE_NOTES.md` file in separate steps.