### PR TITLE
fix: remove native unwind info

### DIFF
--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -45,6 +45,10 @@ impl Default for SpinEngine {
         // turned on for the components we compile.
         let mut config = wasmtime::Config::default();
         config.epoch_interruption(true);
+        // Turn off native unwinding to avoid faulty libunwind detection error
+        // TODO: This can be removed once the Wasmtime fix is brought into Spin
+        // Issue to track: https://github.com/fermyon/spin/issues/2889
+        config.native_unwind_info(false);
         Self {
             wasmtime_engine: wasmtime::Engine::new(&config).unwrap(),
         }


### PR DESCRIPTION
Musl builds of the shim throw a libunwind error during startup due to Wasmtime failing to detect which unwind implementation to use. For now, turn off generating native unwind info. A fix was added to Wasmtime https://github.com/bytecodealliance/wasmtime/pull/9479 and should be in the 27.0.0 release. At that point we can turn this back on if desired.

fixes https://github.com/spinkube/containerd-shim-spin/issues/210