### PR TITLE
Print selective deployment error to container stdio

### DIFF
--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -145,7 +145,10 @@ impl SpinEngine {
             .ok()
             .map(|s| s.split(',').map(|s| s.to_string()).collect::<Vec<String>>());
         if let Some(components) = components_to_execute {
-            crate::retain::retain_components(&mut locked_app, &components)?;
+            if let Err(e) = crate::retain::retain_components(&mut locked_app, &components) {
+                println!("Error with selective deployment: {:?}", e);
+                return Err(e);
+            }
         }
         configure_application_variables_from_environment_variables(&locked_app)?;
         let trigger_cmds = get_supported_triggers(&locked_app)


### PR DESCRIPTION
We currently do not have a way to surface runwasi errors to K8s events. They are only being surfaced in containerd logs which are not intuitive to search. Just as we print trigger information on startup, it makes sense to print error reasons for the time being to make them easier to discover. Take an app with components `hello` and `goodbye`. If i selectively deploy component `foo`, I will now see the following log in the container log:
```sh
Error with selective deployment: Specified component "foo" not found in application
```

Example SpinApp:
```
apiVersion: core.spinkube.dev/v1alpha1
kind: SpinApp
metadata:
  name: hello-salutation-spinap-foop
spec:
  # TODO: change to image hosted at ghcr.io/spinkube/spin-operator/salutations when published
  image: "ghcr.io/kate-goldenring/spin-operator/examples/spin-salutations:20241022-144454"
  replicas: 1
  executor: containerd-shim-spin
  components: ["foo"]
```
ref https://github.com/spinkube/containerd-shim-spin/issues/228