### PR TITLE
fix: enable configuring state_dir with runtime configuration

### DIFF
--- a/containerd-shim-spin/src/constants.rs
+++ b/containerd-shim-spin/src/constants.rs
@@ -21,5 +21,3 @@ pub(crate) const SPIN_TRIGGER_WORKING_DIR: &str = "/";
 /// Defines the subset of application components that should be executable by the shim
 /// If empty or DNE, all components will be supported
 pub(crate) const SPIN_COMPONENTS_TO_RETAIN_ENV: &str = "SPIN_COMPONENTS_TO_RETAIN";
-/// The default state directory for the triggers.
-pub(crate) const SPIN_DEFAULT_STATE_DIR: &str = ".spin";

--- a/containerd-shim-spin/src/trigger.rs
+++ b/containerd-shim-spin/src/trigger.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashSet,
-    future::Future,
-    path::{Path, PathBuf},
-    pin::Pin,
-};
+use std::{collections::HashSet, future::Future, path::Path, pin::Pin};
 
 use log::info;
 use spin_app::{locked::LockedApp, App};
@@ -19,7 +14,7 @@ use trigger_command::CommandTrigger;
 use trigger_mqtt::MqttTrigger;
 use trigger_sqs::SqsTrigger;
 
-use crate::constants::{RUNTIME_CONFIG_PATH, SPIN_DEFAULT_STATE_DIR, SPIN_TRIGGER_WORKING_DIR};
+use crate::constants::{RUNTIME_CONFIG_PATH, SPIN_TRIGGER_WORKING_DIR};
 
 pub(crate) const HTTP_TRIGGER_TYPE: &str = <HttpTrigger as Trigger<TriggerFactors>>::TYPE;
 pub(crate) const REDIS_TRIGGER_TYPE: &str = <RedisTrigger as Trigger<TriggerFactors>>::TYPE;
@@ -54,11 +49,12 @@ fn factors_config() -> FactorsConfig {
         .then(|| RUNTIME_CONFIG_PATH.into());
     // Configure the application state directory path. This is used in the default
     // locations for logs, key value stores, etc.
-    let state_dir = PathBuf::from(SPIN_TRIGGER_WORKING_DIR).join(SPIN_DEFAULT_STATE_DIR);
     FactorsConfig {
         working_dir: SPIN_TRIGGER_WORKING_DIR.into(),
         runtime_config_file,
-        state_dir: UserProvidedPath::Provided(state_dir),
+        // This is the default base for the state_dir (.spin) unless it is
+        // explicitly configured via the runtime config.
+        local_app_dir: Some(SPIN_TRIGGER_WORKING_DIR.to_string()),
         // Explicitly do not set log dir in order to force logs to be displayed to stdout.
         // Otherwise, would default to the state directory.
         log_dir: UserProvidedPath::Unset,


### PR DESCRIPTION
Instead of fixing the `state_dir`, we can set the `local_app_dir` which is [a fallback](https://github.com/fermyon/spin/blob/b98c996201b7fc198cc746b7d78a97d8afcb64d2/crates/runtime-config/src/lib.rs#L223) if the `state_dir` is not set in runtime config like so:
```toml
state_dir = "/Path/to/state-dir/
```

## Walk through
I confirmed this fix works with the following steps using a [simple TODO app](https://github.com/rylev/spin-todo) that creates a SQLite DB in the state store:
```console
$ git clone git@github.com:rylev/spin-todo.git
$ cd spin-todo
# create a directory for the state store
$ mkdir foo
# configure the state dir in runtime config -- note, app root is at `/` so no volume mount needed
$ echo state_dir=\"/.configured" > runtime-config.toml
$ spin build
$ spin registry push ttl.sh/spin-sqlite-todo-123:48h 
$ spin kube scaffold --from ttl.sh/spin-sqlite-todo-123:48h --replicas 1 --runtime-config-file _scratch/runtime-config.toml | k apply -f -
# get container id
$ sudo crictl ps
# now use it to get process id (PID)
$ crictl inspect <container-id> | grep pid
12345
# ensure the SQLite DB is under the configured state dir
$ ls /proc/12345/root/.configured
sqlite_db.db
```

If runtime config is not set -- uses default state_dir of `.spin` at `/`
```sh
$ sudo ls /proc/12345/root/.spin
sqlite_db.db