### PR TITLE
Bump dependencies to Spin v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Bump Spin dependencies to v3.1.2 ([#263](https://github.com/spinkube/containerd-shim-spin/pull/263))
 - Updated the minimum required Rust version to 1.81
 
 ## [v0.17.0](https://github.com/spinkube/containerd-shim-spin/releases/tag/v0.17.0) - 2024-11-08

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,15 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,19 +159,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
+name = "arraydeque"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "async-broadcast"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 2.5.3",
+ "event-listener 5.3.1",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -234,14 +227,13 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "1.6.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
- "async-lock 2.8.0",
- "autocfg",
+ "async-lock",
  "blocking",
- "futures-lite 1.13.0",
+ "futures-lite 2.5.0",
 ]
 
 [[package]]
@@ -252,31 +244,11 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "blocking",
  "futures-lite 2.5.0",
  "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if 1.0.0",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
 ]
 
 [[package]]
@@ -285,26 +257,17 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.5.0",
  "parking",
- "polling 3.7.4",
- "rustix 0.38.42",
+ "polling",
+ "rustix",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -319,21 +282,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "1.8.1"
+name = "async-once-cell"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
-dependencies = [
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "async-signal",
- "blocking",
- "cfg-if 1.0.0",
- "event-listener 3.1.0",
- "futures-lite 1.13.0",
- "rustix 0.38.42",
- "windows-sys 0.48.0",
-]
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
 
 [[package]]
 name = "async-process"
@@ -342,15 +294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel 2.3.1",
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener 5.3.1",
  "futures-lite 2.5.0",
- "rustix 0.38.42",
+ "rustix",
  "tracing",
 ]
 
@@ -371,13 +323,13 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "atomic-waker",
  "cfg-if 1.0.0",
  "futures-core",
  "futures-io",
- "rustix 0.38.42",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -391,9 +343,9 @@ checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 2.4.0",
- "async-lock 3.4.0",
- "async-process 2.3.0",
+ "async-io",
+ "async-lock",
+ "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -493,15 +445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7688e1dfbb9f7804fab0a830820d7e827b8d973906763cf1a855ce4719292f5"
 dependencies = [
  "aws-http",
- "aws-sdk-sso",
- "aws-sdk-sts",
- "aws-smithy-async",
+ "aws-sdk-sso 0.22.0",
+ "aws-sdk-sts 0.22.0",
+ "aws-smithy-async 0.52.0",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.52.0",
  "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-json 0.52.0",
+ "aws-smithy-types 0.52.0",
+ "aws-types 0.52.0",
  "bytes",
  "hex",
  "http 0.2.12",
@@ -515,14 +467,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "1.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a50b30228d3af8865ce83376b4e99e1ffa34728220fe2860e4df0bb5278d6"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso 1.53.0",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts 1.54.1",
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "aws-types 1.3.3",
+ "bytes",
+ "fastrand 2.3.0",
+ "hex",
+ "http 0.2.12",
+ "ring 0.17.8",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-endpoint"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "253d7cd480bfa59a5323390e9e91885a8f06a275e0517d81eeb1070b6aa7d271"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-http 0.52.0",
+ "aws-smithy-types 0.52.0",
+ "aws-types 0.52.0",
  "http 0.2.12",
  "regex",
  "tracing",
@@ -534,15 +528,63 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd1b83859383e46ea8fda633378f9f3f02e6e3a446fd89f0240b5c3662716c9"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-http 0.52.0",
+ "aws-smithy-types 0.52.0",
+ "aws-types 0.52.0",
  "bytes",
  "http 0.2.12",
  "http-body 0.4.6",
  "lazy_static 1.5.0",
  "percent-encoding",
  "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16d1aa50accc11a4b4d5c50f7fb81cc0cf60328259c587d0e6b0f11385bde46"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4 1.2.6",
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "aws-types 1.3.3",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1663eca3983d46e6e6dba3296db31c66f3e2031dc38f0ac2101f8b0f5bb99c5a"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "aws-types 1.3.3",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
@@ -555,14 +597,14 @@ dependencies = [
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
+ "aws-smithy-async 0.52.0",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.52.0",
  "aws-smithy-http-tower",
- "aws-smithy-query",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-query 0.52.0",
+ "aws-smithy-types 0.52.0",
+ "aws-smithy-xml 0.52.0",
+ "aws-types 0.52.0",
  "bytes",
  "http 0.2.12",
  "tokio-stream",
@@ -578,17 +620,61 @@ dependencies = [
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
+ "aws-smithy-async 0.52.0",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.52.0",
  "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-json 0.52.0",
+ "aws-smithy-types 0.52.0",
+ "aws-types 0.52.0",
  "bytes",
  "http 0.2.12",
  "tokio-stream",
  "tower 0.4.13",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1605dc0bf9f0a4b05b451441a17fcb0bda229db384f23bf5cead3adbab0664ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "aws-types 1.3.3",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f3f73466ff24f6ad109095e0f3f2c830bfb4cd6c8b12f744c8e61ebf4d3ba1"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "aws-types 1.3.3",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -600,17 +686,40 @@ dependencies = [
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
+ "aws-smithy-async 0.52.0",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.52.0",
  "aws-smithy-http-tower",
- "aws-smithy-query",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-query 0.52.0",
+ "aws-smithy-types 0.52.0",
+ "aws-smithy-xml 0.52.0",
+ "aws-types 0.52.0",
  "bytes",
  "http 0.2.12",
  "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861d324ef69247c6f3c6823755f408a68877ffb1a9afaff6dd8b0057c760de60"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.61.1",
+ "aws-smithy-query 0.60.7",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "aws-smithy-xml 0.60.9",
+ "aws-types 1.3.3",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
@@ -620,9 +729,9 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6126c4ff918e35fb9ae1bf2de71157fad36f0cc6a2b1d0f7197ee711713700fc"
 dependencies = [
- "aws-sigv4",
- "aws-smithy-http",
- "aws-types",
+ "aws-sigv4 0.52.1",
+ "aws-smithy-http 0.52.0",
+ "aws-types 0.52.0",
  "http 0.2.12",
  "tracing",
 ]
@@ -633,7 +742,7 @@ version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1ee2d9e6e268a77bdf3a0dc2cc8767401627e60abaa32883aaa3d8b47428e9"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.52.0",
  "form_urlencoded",
  "hex",
  "hmac",
@@ -641,6 +750,29 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.2.0",
+ "once_cell",
+ "percent-encoding",
  "sha2",
  "time",
  "tracing",
@@ -659,15 +791,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-async"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427cb637d15d63d6f9aae26358e1c9a9c09d5aa490d64b09354c8217cfef0f28"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "aws-smithy-client"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f505bf793eb3e6d7c166ef1275c27b4b2cd5361173fe950ac8e2cfc08c29a7ef"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-async 0.52.0",
+ "aws-smithy-http 0.52.0",
  "aws-smithy-http-tower",
- "aws-smithy-types",
+ "aws-smithy-types 0.52.0",
  "bytes",
  "fastrand 1.9.0",
  "http 0.2.12",
@@ -687,7 +830,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e4b4304b7ea4af1af3e08535100eb7b6459d5a6264b92078bf85176d04ab85"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.52.0",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -704,13 +847,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-http-tower"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86072ecc4dc4faf3e2071144285cfd539263fe7102b701d54fb991eafb04af8"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.52.0",
+ "aws-smithy-types 0.52.0",
  "bytes",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -725,7 +888,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3ddd9275b167bc59e9446469eca56177ec0b51225632f90aaa2cd5f41c940e"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.52.0",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+dependencies = [
+ "aws-smithy-types 1.2.11",
 ]
 
 [[package]]
@@ -734,8 +906,62 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b19d2e0b3ce20e460bad0d0d974238673100edebba6978c2c1aadd925602f7"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.52.0",
  "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types 1.2.11",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05dd41a70fc74051758ee75b5c4db2c0ca070ed9229c3df50e9475cda1cb985"
+dependencies = [
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "bytes",
+ "fastrand 2.3.0",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.31",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
+dependencies = [
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-types 1.2.11",
+ "bytes",
+ "http 0.2.12",
+ "http 1.2.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -744,11 +970,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "987b1e37febb9bd409ca0846e82d35299e572ad8279bc404778caeb5fc05ad56"
 dependencies = [
- "base64-simd",
+ "base64-simd 0.7.0",
  "itoa",
  "num-integer",
  "ryu",
  "time",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ddc9bd6c28aeb303477170ddd183760a956a03e083b3902a990238a7e3792d"
+dependencies = [
+ "base64-simd 0.8.0",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.2.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -761,19 +1013,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "aws-types"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c05adca3e2bcf686dd2c47836f216ab52ed7845c177d180c84b08522c1166a3"
 dependencies = [
- "aws-smithy-async",
+ "aws-smithy-async 0.52.0",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.52.0",
+ "aws-smithy-types 0.52.0",
  "http 0.2.12",
  "rustc_version",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async 1.2.3",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.2.11",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -797,7 +1072,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.216",
+ "serde",
  "sync_wrapper 0.1.2",
  "tower 0.4.13",
  "tower-layer",
@@ -824,7 +1099,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.216",
+ "serde",
  "sync_wrapper 1.0.2",
  "tower 0.5.2",
  "tower-layer",
@@ -887,7 +1162,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.12.9",
  "rustc_version",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha2",
  "time",
@@ -905,7 +1180,7 @@ dependencies = [
  "azure_core",
  "bytes",
  "futures",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
  "time",
@@ -919,14 +1194,14 @@ name = "azure_identity"
 version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
- "async-lock 3.4.0",
- "async-process 2.3.0",
+ "async-lock",
+ "async-process",
  "async-trait",
  "azure_core",
  "futures",
  "oauth2",
  "pin-project",
- "serde 1.0.216",
+ "serde",
  "time",
  "tracing",
  "tz-rs",
@@ -942,9 +1217,18 @@ dependencies = [
  "async-trait",
  "azure_core",
  "futures",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "time",
+]
+
+[[package]]
+name = "backon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+dependencies = [
+ "fastrand 2.3.0",
 ]
 
 [[package]]
@@ -996,6 +1280,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref 0.5.1",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1330,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitmaps"
@@ -1083,7 +1380,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -1104,7 +1401,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -1125,7 +1422,7 @@ checksum = "7f78efdd7378980d79c0f36b519e51191742d2c9f91ffa5e228fba9f3806d2e1"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes 2.0.4",
+ "io-lifetimes",
  "windows-sys 0.59.0",
 ]
 
@@ -1137,7 +1434,7 @@ checksum = "4ac68674a6042af2bcee1adad9f6abd432642cf03444ce3a5b36c3f39f23baf8"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 0.38.42",
+ "rustix",
  "smallvec",
 ]
 
@@ -1150,10 +1447,10 @@ dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes 2.0.4",
+ "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 0.38.42",
+ "rustix",
  "windows-sys 0.59.0",
  "winx",
 ]
@@ -1176,8 +1473,8 @@ checksum = "c3dbd3e8e8d093d6ccb4b512264869e1281cdb032f7940bd50b2894f96f25609"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes 2.0.4",
- "rustix 0.38.42",
+ "io-lifetimes",
+ "rustix",
 ]
 
 [[package]]
@@ -1190,7 +1487,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 0.38.42",
+ "rustix",
  "winx",
 ]
 
@@ -1230,7 +1527,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1279,8 +1576,8 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.19",
- "serde 1.0.216",
+ "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -1441,18 +1738,21 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.11.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
- "lazy_static 1.5.0",
- "nom 5.1.3",
+ "async-trait",
+ "convert_case",
+ "json5",
+ "nom",
+ "pathdiff",
+ "ron",
  "rust-ini",
- "serde 1.0.216",
- "serde-hjson",
+ "serde",
  "serde_json",
- "toml 0.5.11",
- "yaml-rust",
+ "toml",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -1465,7 +1765,7 @@ dependencies = [
  "json5",
  "libtest-mimic",
  "reqwest 0.12.9",
- "serde 1.0.216",
+ "serde",
  "tar",
  "test-environment",
 ]
@@ -1488,6 +1788,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_fn"
@@ -1524,11 +1844,11 @@ dependencies = [
  "log",
  "mio 1.0.3",
  "nix 0.29.0",
- "oci-spec",
+ "oci-spec 0.6.8",
  "os_pipe",
  "page_size",
  "prctl",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "signal-hook",
  "thiserror 1.0.69",
@@ -1569,9 +1889,9 @@ dependencies = [
  "futures",
  "http 1.2.0",
  "log",
- "oci-spec",
+ "oci-spec 0.6.8",
  "openssl",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "spin-app",
  "spin-common",
@@ -1592,7 +1912,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "tokio",
- "toml 0.8.19",
+ "toml",
  "trigger-command",
  "trigger-mqtt",
  "trigger-sqs",
@@ -1620,9 +1940,9 @@ dependencies = [
  "libcontainer",
  "log",
  "nix 0.28.0",
- "oci-spec",
+ "oci-spec 0.6.8",
  "protobuf 3.2.0",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha256",
  "thiserror 1.0.69",
@@ -1636,10 +1956,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1684,7 +2023,7 @@ version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38da1eb6f7d8cdfa92f05acfae63c9a1d7a337e49ce7a2d0769c7fa03a2613a5"
 dependencies = [
- "serde 1.0.216",
+ "serde",
  "serde_derive",
 ]
 
@@ -1742,7 +2081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70b85ed43567e13782cd1b25baf42a8167ee57169a60dfd3d7307c6ca3839da0"
 dependencies = [
  "cranelift-bitset",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
 ]
 
@@ -1855,6 +2194,12 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -2000,6 +2345,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "futures-util",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "sha2",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,18 +2389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde 1.0.216",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "serde",
 ]
 
 [[package]]
@@ -2140,11 +2492,11 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys 0.3.7",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -2235,7 +2587,7 @@ dependencies = [
  "pin-project",
  "regex",
  "reqwest 0.11.27",
- "serde 1.0.216",
+ "serde",
  "serde_ignored",
  "serde_json",
  "sha2",
@@ -2248,13 +2600,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "docker_credential"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31951f49556e34d90ed28342e1df7e1cb7a229c4cab0aecc627b5d91edd41d07"
 dependencies = [
  "base64 0.21.7",
- "serde 1.0.216",
+ "serde",
  "serde_json",
 ]
 
@@ -2338,13 +2699,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
 dependencies = [
  "enumflags2_derive",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -2381,21 +2748,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if 1.0.0",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "event-listener"
@@ -2458,7 +2825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if 1.0.0",
- "rustix 0.38.42",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -2565,8 +2932,8 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2e6123af26f0f2c51cc66869137080199406754903cc926a7690401ce09cb4"
 dependencies = [
- "io-lifetimes 2.0.4",
- "rustix 0.38.42",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2722,7 +3089,7 @@ dependencies = [
  "bitflags 2.6.0",
  "debugid",
  "fxhash",
- "serde 1.0.216",
+ "serde",
  "serde_json",
 ]
 
@@ -2899,7 +3266,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "serde 1.0.216",
+ "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -2911,6 +3279,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3075,7 +3452,7 @@ dependencies = [
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "serde_qs",
  "serde_urlencoded",
@@ -3153,6 +3530,22 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.31",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3460,7 +3853,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -3471,7 +3864,7 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -3505,19 +3898,8 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
- "io-lifetimes 2.0.4",
+ "io-lifetimes",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3633,7 +4015,7 @@ checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
 dependencies = [
  "pest",
  "pest_derive",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -3646,7 +4028,7 @@ dependencies = [
  "crypto-common",
  "digest",
  "hmac",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha2",
 ]
@@ -3662,16 +4044,19 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "2.3.3"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
+checksum = "2f8fe839464d4e4b37d756d7e910063696af79a7e877282cb1825e4ec5f10833"
 dependencies = [
  "byteorder",
- "lazy_static 1.5.0",
+ "dbus-secret-service",
  "linux-keyutils",
+ "log",
  "secret-service",
- "security-framework",
- "windows-sys 0.52.0",
+ "security-framework 2.11.1",
+ "security-framework 3.0.1",
+ "windows-sys 0.59.0",
+ "zbus",
 ]
 
 [[package]]
@@ -3702,19 +4087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3728,9 +4100,9 @@ checksum = "ef6c844cd81f0e078bb07896a14fddcec9f9582833ce18f99c2d4c9b69081d53"
 dependencies = [
  "fixedbitset 0.5.7",
  "nix 0.28.0",
- "oci-spec",
+ "oci-spec 0.6.8",
  "procfs",
- "serde 1.0.216",
+ "serde",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -3751,7 +4123,7 @@ dependencies = [
  "libseccomp",
  "nc",
  "nix 0.28.0",
- "oci-spec",
+ "oci-spec 0.6.8",
  "once_cell",
  "prctl",
  "procfs",
@@ -3759,7 +4131,7 @@ dependencies = [
  "regex",
  "rust-criu",
  "safe-path",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tracing",
@@ -3858,7 +4230,7 @@ dependencies = [
  "hyper-rustls 0.25.0",
  "libsql-hrana",
  "libsql-sqlite3-parser",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -3876,7 +4248,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "prost 0.12.6",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -3933,12 +4305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-keyutils"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3947,12 +4313,6 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4079,7 +4439,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.42",
+ "rustix",
 ]
 
 [[package]]
@@ -4199,7 +4559,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rand 0.8.5",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "socket2 0.5.8",
  "thiserror 1.0.69",
@@ -4228,11 +4588,11 @@ dependencies = [
  "flate2",
  "lazy_static 1.5.0",
  "num-bigint",
- "num-traits 0.2.19",
+ "num-traits",
  "rand 0.8.5",
  "regex",
  "saturating",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha1",
  "sha2",
@@ -4255,7 +4615,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4333,17 +4693,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -4382,7 +4731,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4392,7 +4741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4401,7 +4750,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4416,7 +4765,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4427,7 +4776,7 @@ checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4438,16 +4787,7 @@ checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.19",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4489,7 +4829,7 @@ dependencies = [
  "getrandom 0.2.15",
  "http 0.2.12",
  "rand 0.8.5",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "serde_path_to_error",
  "sha2",
@@ -4510,10 +4850,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "oci-distribution"
-version = "0.11.0"
+name = "oci-client"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95a2c51531af0cb93761f66094044ca6ea879320bccd35ab747ff3fcab3f422"
+checksum = "474675fdc023fbcc9dcf4782e938a3a1ae5fd469c728d8db40599bd25c77e1ba"
 dependencies = [
  "bytes",
  "chrono",
@@ -4522,10 +4862,11 @@ dependencies = [
  "http-auth",
  "jwt",
  "lazy_static 1.5.0",
+ "oci-spec 0.7.1",
  "olpc-cjson",
  "regex",
  "reqwest 0.12.9",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha2",
  "thiserror 1.0.69",
@@ -4549,7 +4890,7 @@ dependencies = [
  "olpc-cjson",
  "regex",
  "reqwest 0.12.9",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha2",
  "thiserror 1.0.69",
@@ -4568,7 +4909,7 @@ dependencies = [
  "getset",
  "once_cell",
  "regex",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -4576,20 +4917,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "oci-wasm"
-version = "0.0.4"
+name = "oci-spec"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91502e5352f927156f2b6a28d2558cc59558b1f441b681df3f706ced6937e07"
+checksum = "da406e58efe2eb5986a6139626d611ce426e5324a824133d76367c765cf0b882"
+dependencies = [
+ "derive_builder 0.20.2",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.6",
+]
+
+[[package]]
+name = "oci-wasm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f147e207436277483c23cb8e55ccd039ee1657c6a8d19471a6de187da6973ef8"
 dependencies = [
  "anyhow",
  "chrono",
- "oci-distribution 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.216",
+ "oci-client",
+ "serde",
  "serde_json",
  "sha2",
  "tokio",
- "wit-component 0.209.1",
- "wit-parser 0.209.1",
+ "wit-component 0.219.1",
+ "wit-parser 0.219.1",
 ]
 
 [[package]]
@@ -4598,7 +4955,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
 dependencies = [
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "unicode-normalization",
 ]
@@ -4665,23 +5022,35 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.25.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803801d3d3b71cd026851a53f974ea03df3d179cb758b260136a6c9e22e196af"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
  "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8c2b76e5f7848a289aa9666dbe56b16f8a22a4c5246ef37a14941818d2913"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4692,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596b1719b3cab83addb20bcbffdf21575279d9436d9ccccfe651a3bf0ab5ab06"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -4708,13 +5077,14 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c43620e8f93359eb7e627a3b16ee92d8585774986f24f2ab010817426c5ce61"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -4724,16 +5094,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.25.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da0d6b47a3dbc6e9c9e36a0520e25cf943e046843818faaa3f87365a548c82"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand 0.8.5",
@@ -4741,6 +5110,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -4755,7 +5125,17 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4789,6 +5169,12 @@ name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
+
+[[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "overload"
@@ -4910,7 +5296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
  "base64 0.21.7",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -4937,7 +5323,7 @@ dependencies = [
  "pbjson-build",
  "prost 0.12.6",
  "prost-build 0.12.6",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -4947,7 +5333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.1",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -5130,22 +5516,6 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if 1.0.0",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
@@ -5154,7 +5524,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.42",
+ "rustix",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5168,7 +5538,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -5260,12 +5630,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5335,7 +5704,7 @@ dependencies = [
  "hex",
  "lazy_static 1.5.0",
  "procfs-core",
- "rustix 0.38.42",
+ "rustix",
 ]
 
 [[package]]
@@ -5593,16 +5962,15 @@ dependencies = [
 
 [[package]]
 name = "ptree"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
+checksum = "289cfd20ebec0e7ff2572e370dd7a1c9973ba666d3c38c5e747de0a4ada21f17"
 dependencies = [
- "ansi_term",
- "atty",
+ "anstyle",
  "config",
  "directories",
  "petgraph 0.6.5",
- "serde 1.0.216",
+ "serde",
  "serde-value",
  "tint",
 ]
@@ -5804,6 +6172,30 @@ dependencies = [
  "futures-util",
  "itertools 0.13.0",
  "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.8",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f89727cba9cec05cc579942321ff6dd09fe57a8b3217f52f952301efa010da5"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
  "native-tls",
  "num-bigint",
  "percent-encoding",
@@ -5892,6 +6284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5928,7 +6326,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pemfile 1.0.4",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
@@ -5978,7 +6376,7 @@ dependencies = [
  "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
@@ -6045,6 +6443,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.6.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "routefinder"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6066,7 +6476,7 @@ dependencies = [
  "log",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -6082,7 +6492,7 @@ dependencies = [
  "bitflags 2.6.0",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -6101,9 +6511,13 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.13.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -6138,7 +6552,7 @@ dependencies = [
  "http 1.2.0",
  "reqwest 0.12.9",
  "rustify_derive",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "thiserror 1.0.69",
@@ -6162,20 +6576,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes 1.0.11",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
@@ -6184,7 +6584,7 @@ dependencies = [
  "errno",
  "itoa",
  "libc",
- "linux-raw-sys 0.4.14",
+ "linux-raw-sys",
  "once_cell",
  "windows-sys 0.59.0",
 ]
@@ -6203,6 +6603,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -6210,7 +6622,7 @@ dependencies = [
  "log",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -6225,7 +6637,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -6239,7 +6651,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -6252,7 +6664,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -6280,6 +6692,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 dependencies = [
  "web-time",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6384,15 +6806,15 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
- "serde 1.0.216",
+ "serde",
  "zeroize",
 ]
 
 [[package]]
 name = "secret-service"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
 dependencies = [
  "aes",
  "cbc",
@@ -6402,7 +6824,7 @@ dependencies = [
  "num",
  "once_cell",
  "rand 0.8.5",
- "serde 1.0.216",
+ "serde",
  "sha2",
  "zbus",
 ]
@@ -6414,7 +6836,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6436,14 +6871,8 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
- "serde 1.0.216",
+ "serde",
 ]
-
-[[package]]
-name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
@@ -6455,25 +6884,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static 1.5.0",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
-]
-
-[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -6493,7 +6910,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf"
 dependencies = [
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -6505,7 +6922,7 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -6515,7 +6932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -6525,7 +6942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding",
- "serde 1.0.216",
+ "serde",
  "thiserror 1.0.69",
 ]
 
@@ -6546,7 +6963,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -6558,7 +6975,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -6572,7 +6989,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.7.0",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_json",
  "serde_with_macros",
@@ -6600,7 +7017,7 @@ dependencies = [
  "indexmap 2.7.0",
  "itoa",
  "ryu",
- "serde 1.0.216",
+ "serde",
  "unsafe-libyaml",
 ]
 
@@ -6721,7 +7138,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
- "outref",
+ "outref 0.1.0",
 ]
 
 [[package]]
@@ -6761,7 +7178,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -6830,19 +7247,19 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "spin-locked-app",
 ]
 
 [[package]]
 name = "spin-common"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6854,8 +7271,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "tracing",
@@ -6868,8 +7285,8 @@ dependencies = [
 
 [[package]]
 name = "spin-compose"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6883,8 +7300,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6894,8 +7311,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6906,12 +7323,12 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-key-value"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "lru",
- "serde 1.0.216",
+ "serde",
  "spin-core",
  "spin-factors",
  "spin-locked-app",
@@ -6919,32 +7336,33 @@ dependencies = [
  "spin-world",
  "thiserror 1.0.69",
  "tokio",
- "toml 0.8.19",
+ "toml",
  "tracing",
 ]
 
 [[package]]
 name = "spin-factor-llm"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-trait",
- "serde 1.0.216",
+ "serde",
  "spin-factors",
  "spin-llm-remote-http",
  "spin-locked-app",
+ "spin-telemetry",
  "spin-world",
  "tokio",
- "toml 0.8.19",
+ "toml",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "spin-factor-outbound-http"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "http 1.2.0",
@@ -6967,8 +7385,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mqtt"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "rumqttc",
@@ -6983,8 +7401,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mysql"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -7000,8 +7418,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -7010,7 +7428,7 @@ dependencies = [
  "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
- "serde 1.0.216",
+ "serde",
  "spin-expressions",
  "spin-factor-variables",
  "spin-factor-wasi",
@@ -7026,8 +7444,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-pg"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7045,8 +7463,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-redis"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "redis 0.25.4",
@@ -7060,8 +7478,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-sqlite"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "async-trait",
  "spin-factors",
@@ -7074,8 +7492,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-variables"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "spin-expressions",
  "spin-factors",
@@ -7085,8 +7503,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-wasi"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7099,22 +7517,22 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
- "serde 1.0.216",
+ "serde",
  "spin-app",
  "spin-factors-derive",
  "thiserror 1.0.69",
- "toml 0.8.19",
+ "toml",
  "wasmtime",
 ]
 
 [[package]]
 name = "spin-factors-derive"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7123,8 +7541,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-executor"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "spin-app",
@@ -7134,8 +7552,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "http 1.2.0",
@@ -7144,7 +7562,7 @@ dependencies = [
  "indexmap 2.7.0",
  "percent-encoding",
  "routefinder",
- "serde 1.0.216",
+ "serde",
  "spin-app",
  "tracing",
  "wasmtime",
@@ -7152,28 +7570,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-key-value-aws"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
+dependencies = [
+ "anyhow",
+ "async-once-cell",
+ "aws-config 1.5.13",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "serde",
+ "spin-core",
+ "spin-factor-key-value",
+]
+
+[[package]]
 name = "spin-key-value-azure"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "azure_core",
  "azure_data_cosmos",
  "azure_identity",
  "futures",
- "serde 1.0.216",
+ "serde",
  "spin-core",
  "spin-factor-key-value",
 ]
 
 [[package]]
 name = "spin-key-value-redis"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
- "redis 0.27.6",
- "serde 1.0.216",
+ "redis 0.28.1",
+ "serde",
  "spin-core",
  "spin-factor-key-value",
  "tokio",
@@ -7182,12 +7615,12 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-spin"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "rusqlite",
- "serde 1.0.216",
+ "serde",
  "spin-core",
  "spin-factor-key-value",
  "spin-world",
@@ -7196,12 +7629,12 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "reqwest 0.12.9",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "spin-telemetry",
  "spin-world",
@@ -7210,8 +7643,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -7220,7 +7653,7 @@ dependencies = [
  "path-absolutize",
  "reqwest 0.12.9",
  "semver",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha2",
  "spin-common",
@@ -7230,19 +7663,19 @@ dependencies = [
  "spin-serde",
  "tempfile",
  "tokio",
- "toml 0.8.19",
+ "toml",
  "tracing",
- "wasm-pkg-loader",
+ "wasm-pkg-client",
 ]
 
 [[package]]
 name = "spin-locked-app"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-trait",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "spin-serde",
  "thiserror 1.0.69",
@@ -7250,25 +7683,25 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
  "semver",
- "serde 1.0.216",
+ "serde",
  "spin-serde",
  "terminal",
  "thiserror 1.0.69",
- "toml 0.8.19",
+ "toml",
  "url",
  "wasm-pkg-common",
 ]
 
 [[package]]
 name = "spin-oci"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7280,9 +7713,9 @@ dependencies = [
  "docker_credential",
  "futures-util",
  "itertools 0.13.0",
- "oci-distribution 0.11.0 (git+https://github.com/fermyon/oci-distribution?rev=7e4ce9be9bcd22e78a28f06204931f10c44402ba)",
+ "oci-distribution",
  "reqwest 0.12.9",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "spin-common",
  "spin-loader",
@@ -7296,13 +7729,13 @@ dependencies = [
 
 [[package]]
 name = "spin-resource-table"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 
 [[package]]
 name = "spin-runtime-config"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "spin-common",
@@ -7318,19 +7751,20 @@ dependencies = [
  "spin-factor-variables",
  "spin-factor-wasi",
  "spin-factors",
+ "spin-key-value-aws",
  "spin-key-value-azure",
  "spin-key-value-redis",
  "spin-key-value-spin",
  "spin-sqlite",
  "spin-trigger",
  "spin-variables",
- "toml 0.8.19",
+ "toml",
 ]
 
 [[package]]
 name = "spin-runtime-factors"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -7356,33 +7790,33 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "semver",
- "serde 1.0.216",
+ "serde",
  "wasm-pkg-common",
 ]
 
 [[package]]
 name = "spin-sqlite"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
- "serde 1.0.216",
+ "serde",
  "spin-factor-sqlite",
  "spin-factors",
  "spin-sqlite-inproc",
  "spin-sqlite-libsql",
- "toml 0.8.19",
+ "toml",
 ]
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7394,8 +7828,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7407,13 +7841,14 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "http 0.2.12",
  "http 1.2.0",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "terminal",
@@ -7424,15 +7859,15 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
  "ctrlc",
  "futures",
  "sanitize-filename",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "spin-app",
  "spin-common",
@@ -7451,8 +7886,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -7464,7 +7899,7 @@ dependencies = [
  "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "spin-app",
  "spin-core",
@@ -7486,13 +7921,13 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "anyhow",
  "futures",
  "redis 0.27.6",
- "serde 1.0.216",
+ "serde",
  "spin-factor-variables",
  "spin-factors",
  "spin-telemetry",
@@ -7504,14 +7939,14 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "azure_core",
  "azure_identity",
  "azure_security_keyvault",
  "dotenvy",
- "serde 1.0.216",
+ "serde",
  "spin-expressions",
  "spin-factor-variables",
  "spin-factors",
@@ -7523,8 +7958,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "async-trait",
  "wasmtime",
@@ -7702,7 +8137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -7713,7 +8148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -7747,8 +8182,8 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
- "io-lifetimes 2.0.4",
- "rustix 0.38.42",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.59.0",
  "winx",
 ]
@@ -7794,7 +8229,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.3.0",
  "once_cell",
- "rustix 0.38.42",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -7809,8 +8244,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.2"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.2#3d37bd8cdd1ddbfc94b9670540fbf9eb09687c2a"
 dependencies = [
  "termcolor",
 ]
@@ -7906,7 +8341,7 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde 1.0.216",
+ "serde",
  "time-core",
  "time-macros",
 ]
@@ -7934,6 +8369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
 dependencies = [
  "lazy_static 0.2.11",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -8050,6 +8494,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
@@ -8118,24 +8572,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde 1.0.216",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "indexmap 2.7.0",
- "serde 1.0.216",
+ "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -8144,18 +8589,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
- "serde 1.0.216",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.7.0",
- "toml_datetime",
- "winnow 0.5.40",
+ "serde",
 ]
 
 [[package]]
@@ -8165,10 +8599,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.7.0",
- "serde 1.0.216",
+ "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -8322,9 +8756,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eabc56d23707ad55ba2a0750fc24767125d5a0f51993ba41ad2c441cc7b8dea"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -8343,7 +8777,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
- "serde 1.0.216",
+ "serde",
  "tracing-core",
 ]
 
@@ -8357,7 +8791,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -8369,13 +8803,13 @@ dependencies = [
 
 [[package]]
 name = "trigger-command"
-version = "0.2.0"
-source = "git+https://github.com/fermyon/spin-trigger-command?tag=v0.2.0#20deea19039069ad77a82b251dc696220b8b5cbd"
+version = "0.2.2"
+source = "git+https://github.com/fermyon/spin-trigger-command?tag=v0.2.2#f68e7a364f1a131651c0113389c9ed656e9c5650"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
  "openssl",
- "serde 1.0.216",
+ "serde",
  "spin-core",
  "spin-factor-wasi",
  "spin-factors",
@@ -8384,19 +8818,18 @@ dependencies = [
  "spin-trigger",
  "tokio",
  "tracing",
- "wasmtime-wasi",
 ]
 
 [[package]]
 name = "trigger-mqtt"
-version = "0.3.0"
-source = "git+https://github.com/spinkube/spin-trigger-mqtt?tag=v0.3.0#8827aa0f591cc4af9ed12e19e517ab392f90fa43"
+version = "0.3.2"
+source = "git+https://github.com/spinkube/spin-trigger-mqtt?tag=v0.3.2#9a906cba78ff9d72f836367048d67772cdc408b2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
  "futures",
  "paho-mqtt",
- "serde 1.0.216",
+ "serde",
  "spin-app",
  "spin-core",
  "spin-expressions",
@@ -8412,16 +8845,16 @@ dependencies = [
 
 [[package]]
 name = "trigger-sqs"
-version = "0.8.0"
-source = "git+https://github.com/fermyon/spin-trigger-sqs?tag=v0.8.0#ce305390c9d6f45b322eeeace98943558e291a82"
+version = "0.8.2"
+source = "git+https://github.com/fermyon/spin-trigger-sqs?tag=v0.8.2#3da15096e64c18ec250e0dc5ee07557b390de06d"
 dependencies = [
  "anyhow",
- "aws-config",
+ "aws-config 0.52.0",
  "aws-sdk-sqs",
  "clap 3.2.25",
  "futures",
  "openssl",
- "serde 1.0.216",
+ "serde",
  "spin-core",
  "spin-factors",
  "spin-runtime-factors",
@@ -8619,7 +9052,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -8680,7 +9113,7 @@ dependencies = [
  "reqwest 0.12.9",
  "rustify",
  "rustify_derive",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tracing",
@@ -8698,6 +9131,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wac-graph"
@@ -8759,13 +9198,13 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a22d3c9026f2f6a628cf386963844cdb7baea3b3419ba090c9096da114f977d"
+checksum = "f98505d42b5289563c6d659f625b6789a97980166508bd00862c4328bf41c261"
 dependencies = [
  "indexmap 2.7.0",
  "itertools 0.12.1",
- "serde 1.0.216",
+ "serde",
  "serde_with",
  "thiserror 1.0.69",
  "warg-crypto",
@@ -8774,9 +9213,9 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8b5a2b17e737e1847dbf4642e4ebe49f5df32a574520251ff080ef0a120423"
+checksum = "738a33cf369dea5d2684a61a7035c038858f40fc090d4981d35ee3fab416ddb8"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8797,7 +9236,7 @@ dependencies = [
  "reqwest 0.12.9",
  "secrecy",
  "semver",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha256",
  "tempfile",
@@ -8820,9 +9259,9 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834bf58863aa4bc3821732afb0c77e08a5cbf05f63ee93116acae694eab04460"
+checksum = "71661a52504e20b9ec8e9846bddda041f30eb7aedeb6888c057d6a213eaedf87"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8833,7 +9272,7 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "secrecy",
- "serde 1.0.216",
+ "serde",
  "sha2",
  "signature",
  "thiserror 1.0.69",
@@ -8841,9 +9280,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8a2dee6b14f5b0b0c461711a81cdef45d45ea94f8460cb6205cada7fec732a"
+checksum = "6af0b1733deeb4f0c496d2b8e3ddb0e93b39da19d90c4f6d7594f2861f7e3086"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -8854,15 +9293,15 @@ dependencies = [
  "prost-types 0.12.6",
  "protox",
  "regex",
- "serde 1.0.216",
+ "serde",
  "warg-crypto",
 ]
 
 [[package]]
 name = "warg-protocol"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4053a3276d3fee83645411b1b5f462f72402e70fbf645164274a3a0a2fd72538"
+checksum = "922504990dbb7297c67139140fc5c08f596988fcbaf38d9e7d3bf89a0c0759fe"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8872,7 +9311,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "semver",
- "serde 1.0.216",
+ "serde",
  "serde_with",
  "thiserror 1.0.69",
  "warg-crypto",
@@ -8883,9 +9322,9 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513ef81a5bb1ac5d7bd04f90d3c192dad8f590f4c02b3ef68d3ae4fbbb53c1d7"
+checksum = "8b8d8110b6800c43422676201a6a62167769b015ca29a8fcab67d789ac8b9c63"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
@@ -8992,7 +9431,7 @@ dependencies = [
  "indexmap 2.7.0",
  "log",
  "petgraph 0.6.5",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_yaml",
  "smallvec",
@@ -9022,21 +9461,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
 dependencies = [
  "leb128",
  "wasmparser 0.217.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.219.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
+dependencies = [
+ "leb128",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
@@ -9057,28 +9497,12 @@ checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_json",
  "spdx",
  "wasm-encoder 0.202.0",
  "wasmparser 0.202.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
-dependencies = [
- "anyhow",
- "indexmap 2.7.0",
- "serde 1.0.216",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.209.1",
- "wasmparser 0.209.1",
 ]
 
 [[package]]
@@ -9089,7 +9513,7 @@ checksum = "65a146bf9a60e9264f0548a2599aa9656dba9a641eff9ab88299dc2a637e483c"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_json",
  "spdx",
@@ -9098,52 +9522,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-pkg-common"
-version = "0.4.1"
+name = "wasm-metadata"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7a687d110f68a65227a644c7040c7720220e8cb0bb8c803e2b5dcb7fd72468"
+checksum = "2af5a8e37a5e996861e1813f8de30911c47609c9ff51a7284f7dbd754dc3a9f3"
 dependencies = [
  "anyhow",
- "dirs 5.0.1",
- "http 1.2.0",
- "reqwest 0.12.9",
- "semver",
- "serde 1.0.216",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
  "serde_json",
- "thiserror 1.0.69",
- "toml 0.8.19",
- "tracing",
+ "spdx",
+ "wasm-encoder 0.219.1",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
-name = "wasm-pkg-loader"
-version = "0.4.1"
+name = "wasm-pkg-client"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11338b173351bc505bc752c00068a7d1da5106a9d351753f0d01267dcc4747b2"
+checksum = "ce4df26ea869f36b1f7dcd83a3327a1864492281406d48d5dc529a199a3074e3"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "dirs 5.0.1",
  "docker_credential",
+ "etcetera",
  "futures-util",
- "oci-distribution 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oci-client",
  "oci-wasm",
  "secrecy",
- "serde 1.0.216",
+ "serde",
  "serde_json",
  "sha2",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
- "toml 0.8.19",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
  "warg-client",
+ "warg-crypto",
  "warg-protocol",
+ "wasm-metadata 0.219.1",
  "wasm-pkg-common",
+ "wit-component 0.219.1",
+]
+
+[[package]]
+name = "wasm-pkg-common"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14acb8e490839c93364c23716feb9af0dd93e0638b8b5e083b1d0803b7ea595"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "etcetera",
+ "futures-util",
+ "http 1.2.0",
+ "reqwest 0.12.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -9183,19 +9630,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
-dependencies = [
- "ahash",
- "bitflags 2.6.0",
- "hashbrown 0.14.5",
- "indexmap 2.7.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
@@ -9205,7 +9639,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
  "semver",
- "serde 1.0.216",
+ "serde",
 ]
 
 [[package]]
@@ -9219,7 +9653,20 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
  "semver",
- "serde 1.0.216",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.219.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
+dependencies = [
+ "ahash",
+ "bitflags 2.6.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.7.0",
+ "semver",
 ]
 
 [[package]]
@@ -9284,9 +9731,9 @@ dependencies = [
  "postcard",
  "psm",
  "rayon",
- "rustix 0.38.42",
+ "rustix",
  "semver",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
@@ -9330,11 +9777,11 @@ dependencies = [
  "directories-next",
  "log",
  "postcard",
- "rustix 0.38.42",
- "serde 1.0.216",
+ "rustix",
+ "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.19",
+ "toml",
  "windows-sys 0.52.0",
  "zstd",
 ]
@@ -9402,7 +9849,7 @@ dependencies = [
  "postcard",
  "rustc-demangle",
  "semver",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "target-lexicon",
  "wasm-encoder 0.217.0",
@@ -9421,7 +9868,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "rustix 0.38.42",
+ "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.52.0",
@@ -9435,7 +9882,7 @@ checksum = "106731c6ebe1d551362ee8c876d450bdc2d517988b20eb3653dc4837b1949437"
 dependencies = [
  "object",
  "once_cell",
- "rustix 0.38.42",
+ "rustix",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -9465,7 +9912,7 @@ checksum = "c6d83a7816947a4974e2380c311eacb1db009b8bad86081dc726b705603c93c7"
 dependencies = [
  "anyhow",
  "cranelift-entity",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "smallvec",
  "wasmparser 0.217.0",
@@ -9500,9 +9947,9 @@ dependencies = [
  "fs-set-times",
  "futures",
  "io-extras",
- "io-lifetimes 2.0.4",
+ "io-lifetimes",
  "once_cell",
- "rustix 0.38.42",
+ "rustix",
  "system-interface",
  "thiserror 1.0.69",
  "tokio",
@@ -9653,7 +10100,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.42",
+ "rustix",
 ]
 
 [[package]]
@@ -9946,15 +10393,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
@@ -9984,25 +10422,6 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
-dependencies = [
- "anyhow",
- "bitflags 2.6.0",
- "indexmap 2.7.0",
- "log",
- "serde 1.0.216",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.209.1",
- "wasm-metadata 0.209.1",
- "wasmparser 0.209.1",
- "wit-parser 0.209.1",
-]
-
-[[package]]
-name = "wit-component"
 version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7117809905e49db716d81e794f79590c052bf2fdbbcda1731ca0fb28f6f3ddf"
@@ -10011,7 +10430,7 @@ dependencies = [
  "bitflags 2.6.0",
  "indexmap 2.7.0",
  "log",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.217.0",
@@ -10021,21 +10440,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-parser"
-version = "0.209.1"
+name = "wit-component"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
+checksum = "ad1673163c0cb14a6a19ddbf44dd4efe6f015ec1ebb8156710ac32501f19fba2"
 dependencies = [
  "anyhow",
- "id-arena",
+ "bitflags 2.6.0",
  "indexmap 2.7.0",
  "log",
- "semver",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.209.1",
+ "wasm-encoder 0.219.1",
+ "wasm-metadata 0.219.1",
+ "wasmparser 0.219.1",
+ "wit-parser 0.219.1",
 ]
 
 [[package]]
@@ -10049,11 +10469,29 @@ dependencies = [
  "indexmap 2.7.0",
  "log",
  "semver",
- "serde 1.0.216",
+ "serde",
  "serde_derive",
  "serde_json",
  "unicode-xid",
  "wasmparser 0.217.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.219.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
@@ -10096,8 +10534,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.14",
- "rustix 0.38.42",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]
@@ -10117,12 +10555,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
+name = "yaml-rust2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
 dependencies = [
- "linked-hash-map",
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.8.4",
 ]
 
 [[package]]
@@ -10131,7 +10571,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
- "serde 1.0.216",
+ "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -10151,39 +10591,36 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "3.15.2"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
 dependencies = [
  "async-broadcast",
  "async-executor",
  "async-fs",
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "async-process 1.8.1",
+ "async-io",
+ "async-lock",
+ "async-process",
  "async-recursion",
  "async-task",
  "async-trait",
  "blocking",
- "byteorder",
- "derivative",
  "enumflags2",
- "event-listener 2.5.3",
+ "event-listener 5.3.1",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hex",
- "nix 0.26.4",
- "once_cell",
+ "nix 0.29.0",
  "ordered-stream",
  "rand 0.8.5",
- "serde 1.0.216",
+ "serde",
  "serde_repr",
  "sha1",
  "static_assertions",
  "tracing",
  "uds_windows",
- "winapi",
+ "windows-sys 0.52.0",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -10192,25 +10629,24 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.15.2"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "regex",
- "syn 1.0.109",
+ "syn 2.0.90",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
 dependencies = [
- "serde 1.0.216",
+ "serde",
  "static_assertions",
  "zvariant",
 ]
@@ -10315,38 +10751,37 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "3.15.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
 dependencies = [
- "byteorder",
+ "endi",
  "enumflags2",
- "libc",
- "serde 1.0.216",
+ "serde",
  "static_assertions",
  "zvariant_derive",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "3.15.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
 ]

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -15,28 +15,28 @@ containerd-shim-wasm = { version ="0.7.0", default-features = false }
 containerd-shim = "0.7.4"
 http = "1"
 log = "0.4"
-spin-app = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-componentize = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
+spin-app = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-componentize = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
 # Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v3.0.0", features = [
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v3.1.2", features = [
     "unsafe-aot-compilation",
 ] }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-trigger-mqtt = { git = "https://github.com/spinkube/spin-trigger-mqtt", tag = "v0.3.0" }
-trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", tag = "v0.8.0" }
-trigger-command = { git = "https://github.com/fermyon/spin-trigger-command", tag = "v0.2.0" }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-oci = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-common = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-factors-executor = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-telemetry = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-runtime-factors = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-factors = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-factor-outbound-networking = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-trigger-redis = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+trigger-mqtt = { git = "https://github.com/spinkube/spin-trigger-mqtt", tag = "v0.3.2" }
+trigger-sqs = { git = "https://github.com/fermyon/spin-trigger-sqs", tag = "v0.8.2" }
+trigger-command = { git = "https://github.com/fermyon/spin-trigger-command", tag = "v0.2.2" }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-oci = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-common = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-expressions = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-factors-executor = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-telemetry = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-runtime-factors = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-factors = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
+spin-factor-outbound-networking = { git = "https://github.com/fermyon/spin", tag = "v3.1.2" }
 wasmtime = "25"
 tokio = { version = "1", features = ["rt"] }
 openssl = { version = "*", features = ["vendored"] }


### PR DESCRIPTION
Pulls in release of Spin that fixes issue with dropped Redis connections. Draft until the triggers are released