### PR TITLE
docs(*): add deprecation notice for node-installer; refer to runtime-class-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In order to run Spin applications on your cluster, you must complete the followi
 2. Update the containerd configuration to recognize the shim
 3. Apply the Kubernetes `RuntimeClass` for the shim
 
-Repeating steps 1 and 2 for each node on a cluster can be a time-consuming and manual process. For this reason, SpinKube provides a [`runtime-class-manager`](https://www.spinkube.dev/docs/topics/architecture/#runtime-class-manager) (previously the `kwasm` operator) that enables you to skip over step 1 and 2. See the [SpinKube installation guide](https://www.spinkube.dev/docs/install/installing-with-helm/) for more information on installing with Helm.
+Repeating these steps for each node on a cluster can be a time-consuming and manual process. For this reason, SpinKube provides a [`runtime-class-manager`](https://www.spinkube.dev/docs/topics/architecture/#runtime-class-manager) (previously the `kwasm` operator) that automates all of the steps. See the [SpinKube installation guide](https://www.spinkube.dev/docs/install/installing-with-helm/) for more information on installing with Helm.
 
 To carry out the installation step-by-step, do the following:
 
@@ -80,7 +80,7 @@ To carry out the installation step-by-step, do the following:
       SystemdCgroup = true
     ```
 
-    The [Node Installer script](./node-installer/script/installer.sh) that is used by the [`runtime-class-manager`](https://www.spinkube.dev/docs/topics/architecture/#runtime-class-manager) does this for you and is a good reference to understand the common paths to the containerd configuration file for popular Kubernetes distributions.
+    The deprecated [Node Installer script](./node-installer/script/installer.sh) that was used by the [`kwasm-operator`](https://github.com/kwasm/kwasm-operator) (now superseded by [`runtime-class-manager`](https://www.spinkube.dev/docs/topics/architecture/#runtime-class-manager) which has its own installation logic) is a good reference to understand the common paths to the containerd configuration file for popular Kubernetes distributions.
 
 3. Apply a runtime class that contains a handler that matches the "spin" config runtime name from step 2.
 

--- a/node-installer/README.md
+++ b/node-installer/README.md
@@ -1,12 +1,14 @@
+> Note: the [spinframework/runtime-class-manager](https://github.com/spinframework/runtime-class-manager)
+project now handles installing containerd-shim-spin-v2 onto Nodes in SpinKube,
+meaning this project's node-installer is no longer used. However, it will still
+be offered here for a period of time for use with older installations.
+
 This directory contains resources for a custom node-installer image
-intended to be used in conjunction with the [Kwasm Operator](https://github.com/KWasm/kwasm-operator).
+used in conjunction with the [Kwasm Operator](https://github.com/KWasm/kwasm-operator).
 
 This version of the image only contains the containerd-shim-spin-v2 shim, as
 opposed to the default [kwasm-node-installer image](https://github.com/KWasm/kwasm-node-installer)
 which also bundles other shims.
-
-The intention is for the [spinframework/runtime-class-manager](https://github.com/spinframework/runtime-class-manager)
-project to handle this concern in the future.
 
 ## Integration Tests
 

--- a/node-installer/script/installer.sh
+++ b/node-installer/script/installer.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
 set -euo pipefail
 
+# Note: this script is now deprecated and no longer used in the context of more recent versions
+# of SpinKube. Instead, the runtime-class-manager project handles installation of the Spin shim.
+# See https://github.com/spinframework/runtime-class-manager/blob/main/README.md for more details.
+
 # Based on https://github.com/KWasm/kwasm-node-installer/blob/main/script/installer.sh
 # Distilled to only configuring the Spin shim
 


### PR DESCRIPTION
Add docs mentioning the replacement of this project's node-installer script with use of runtime-class-manager in SpinKube.

Ref https://github.com/spinframework/spinkube-docs/issues/340

Do others have opinions on adding further process to deprecating the node-installer component in this repo?  I'm not sure if we need/want it to continue to live on (e.g. for SpinKube installations still using kwasm-operator) or if we can/should remove the component (and corresponding CI/CD) entirely.  Ideally we avoid supporting both this component and the go-based logic in runtime-class-manager (e.g. with bug fixes, patches, new features, etc).

Depends on:
- [x]  Would be good to wait until the docs PR is merged -> https://github.com/spinframework/spinkube-docs/pull/339