### PR TITLE
fix: update traefik API group and remove strip-prefix middleware

### DIFF
--- a/containerd-shim-spin/quickstart.md
+++ b/containerd-shim-spin/quickstart.md
@@ -31,13 +31,13 @@ Deploy a pre-built sample spin application:
 kubectl apply -f https://raw.githubusercontent.com/spinframework/containerd-shim-spin/main/deployments/workloads/workload.yaml
 echo "waiting 5 seconds for workload to be ready"
 sleep 5
-curl -v http://0.0.0.0:8081/spin/hello
+curl -v http://0.0.0.0:8081/hello
 ```
 
 Confirm you see a response from the sample application. For example:
 
 ```output
-$ curl -v http://0.0.0.0:8081/spin/hello
+$ curl -v http://0.0.0.0:8081/hello
 *   Trying 0.0.0.0:8081...
 * TCP_NODELAY set
 * Connected to 0.0.0.0 (127.0.0.1) port 8081 (#0)

--- a/deployments/k3d/workload/workload.yaml
+++ b/deployments/k3d/workload/workload.yaml
@@ -37,7 +37,6 @@ metadata:
   name: wasm-ingress
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    traefik.ingress.kubernetes.io/router.middlewares: default-strip-prefix@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -43,7 +43,6 @@ metadata:
   name: wasm-ingress
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    traefik.ingress.kubernetes.io/router.middlewares: default-strip-prefix@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/images/spin-dapr/deploy.yaml
+++ b/images/spin-dapr/deploy.yaml
@@ -44,8 +44,8 @@ metadata:
   name: spin-dapr
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:

--- a/tests/workloads-pushed-using-docker-build-push/workloads.yaml
+++ b/tests/workloads-pushed-using-docker-build-push/workloads.yaml
@@ -122,7 +122,7 @@ spec:
 ---
 # Middleware
 # Strip prefix /spin
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: strip-prefix

--- a/tests/workloads-pushed-using-spin-registry-push/workloads.yaml
+++ b/tests/workloads-pushed-using-spin-registry-push/workloads.yaml
@@ -122,7 +122,7 @@ spec:
 ---
 # Middleware
 # Strip prefix /spin
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: strip-prefix

--- a/tests/workloads-pushed-using-wkg-oci-push/workloads.yaml
+++ b/tests/workloads-pushed-using-wkg-oci-push/workloads.yaml
@@ -40,7 +40,7 @@ spec:
 ---
 # Middleware
 # Strip prefix /spin
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: strip-prefix


### PR DESCRIPTION
Update Middleware resources from deprecated `traefik.containo.us/v1alpha1` to `traefik.io/v1alpha1`. Remove the strip-prefix middleware annotation from Ingress resources and fix the quickstart `curl` example to use `/hello` directly.