### PR TITLE
chore: arm64 compilation for developer

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,4 +8,4 @@ rustflags = ["-C", "target-feature=+fp16", "-C", "target-feature=+crt-static", "
 
 [target.x86_64-unknown-linux-musl]
 # see https://github.com/fermyon/spin/pull/2307/files#diff-f6009bd0d260464389ace37ab2f89adae993e1fa4a47f779e4c9859937005ced
-rustflags = ["-C", "target-feature=+crt-static", "-C", "link-self-contained=yes"]
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-self-contained=yes", "-C", "relocation-model=static"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,7 +2,7 @@
 default-target = "x86_64-unknown-linux-musl"
 
 [target.x86_64-unknown-linux-musl]
-dockerfile = "./cross/Dockerfile"
+dockerfile = { file = "./cross/Dockerfile", build-args = { CROSS_CMAKE_SYSTEM_PROCESSOR = "x86_64", CROSS_SYSROOT = "/usr/local/x86_64-linux-musl" } }
 
 [target.aarch64-unknown-linux-musl]
-dockerfile = "./cross/Dockerfile"
+dockerfile = { file = "./cross/Dockerfile", build-args = { CROSS_CMAKE_SYSTEM_PROCESSOR = "aarch64", CROSS_SYSROOT = "/usr/local/aarch64-linux-musl" } } 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PREFIX ?= /usr/local
 INSTALL ?= install
 ARCH ?= x86_64
 TARGET ?= $(ARCH)-unknown-linux-musl
+DOCKER_DEFAULT_PLATFORM ?= linux/amd64
 CONTAINERD_NAMESPACE ?= default
 TEST_IMG_NAME ?= wasmtest_spin:latest
 CTR_FLAGS ?=

--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -1,6 +1,11 @@
 ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
 
+ARG CROSS_CMAKE_SYSTEM_PROCESSOR
+ARG CROSS_SYSROOT
+
+ENV CROSS_TOOLCHAIN_PREFIX=${CROSS_CMAKE_SYSTEM_PROCESSOR}-linux-musl-
+
 # Build libseccomp from source against the musl sysroot.
 # libseccomp-rs requires a static musl-linked libseccomp; we compile it here
 # using the cross-rs musl toolchain so we don't depend on any third-party images.


### PR DESCRIPTION
- ~switching `Cross.toml` base images to Docker Hub mirrors (avoiding unauthenticated GHCR failures) Created a new Cross dev configuration instead~
- ~adding `-C relocation-model=static` for the Alpine musl toolchain~
- ~making `unit-tests`rule use cross test on non-Linux hosts.~

---
Update after https://github.com/spinframework/containerd-shim-spin/commit/5b536949fbe1cd9685a56ea1b8fbe22b4a2e8346:
- Now overriding docker platform to pull amd64 image
- specify some cross env variables for multi arch build