### PR TITLE
feat: allow configuration of idle instance timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ name = "containerd-shim-spin-v2"
 version = "0.24.0"
 dependencies = [
  "anyhow",
+ "clap 3.2.25",
  "containerd-shim-wasm",
  "ctrlc",
  "futures",

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -33,6 +33,7 @@ spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin
 wasmtime = "42.0.2"
 openssl = { version = "*", features = ["vendored"] }
 anyhow = "1.0"
+clap = { version = "3", features = ["derive"] }
 oci-spec = "0.7"
 futures = "0.3"
 ctrlc = { version = "3.5", features = ["termination"] }

--- a/containerd-shim-spin/src/constants.rs
+++ b/containerd-shim-spin/src/constants.rs
@@ -23,3 +23,13 @@ pub(crate) const SPIN_TRIGGER_WORKING_DIR: &str = "/";
 /// Defines the subset of application components that should be executable by the shim
 /// If empty or DNE, all components will be supported
 pub(crate) const SPIN_COMPONENTS_TO_RETAIN_ENV: &str = "SPIN_COMPONENTS_TO_RETAIN";
+/// Environment variable to set the idle instance timeout for the HTTP trigger
+pub(crate) const SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_ENV: &str = "SPIN_HTTP_IDLE_INSTANCE_TIMEOUT";
+/// Environment variable to set the max instance reuse count for the HTTP trigger
+pub(crate) const SPIN_HTTP_MAX_INSTANCE_REUSE_COUNT_ENV: &str =
+    "SPIN_HTTP_MAX_INSTANCE_REUSE_COUNT";
+/// Environment variable to set the max concurrent instance reuse count for the HTTP trigger
+pub(crate) const SPIN_HTTP_MAX_INSTANCE_CONCURRENT_REUSE_COUNT_ENV: &str =
+    "SPIN_HTTP_MAX_INSTANCE_CONCURRENT_REUSE_COUNT";
+/// Environment variable to set the request timeout for the HTTP trigger
+pub(crate) const SPIN_HTTP_REQUEST_TIMEOUT_ENV: &str = "SPIN_HTTP_REQUEST_TIMEOUT";

--- a/containerd-shim-spin/src/constants.rs
+++ b/containerd-shim-spin/src/constants.rs
@@ -25,6 +25,8 @@ pub(crate) const SPIN_TRIGGER_WORKING_DIR: &str = "/";
 pub(crate) const SPIN_COMPONENTS_TO_RETAIN_ENV: &str = "SPIN_COMPONENTS_TO_RETAIN";
 /// Environment variable to set the idle instance timeout for the HTTP trigger
 pub(crate) const SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_ENV: &str = "SPIN_HTTP_IDLE_INSTANCE_TIMEOUT";
+/// Default idle instance timeout, matching the spin-trigger-http default
+pub(crate) const SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_DEFAULT: &str = "1s";
 /// Environment variable to set the max instance reuse count for the HTTP trigger
 pub(crate) const SPIN_HTTP_MAX_INSTANCE_REUSE_COUNT_ENV: &str =
     "SPIN_HTTP_MAX_INSTANCE_REUSE_COUNT";

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -213,7 +213,7 @@ impl SpinSandbox {
 /// HTTP trigger configuration read from environment variables.
 struct HttpTriggerEnvConfig {
     listen: String,
-    idle_instance_timeout: Option<String>,
+    idle_instance_timeout: String,
     max_instance_reuse_count: Option<String>,
     max_instance_concurrent_reuse_count: Option<String>,
     request_timeout: Option<String>,
@@ -225,7 +225,8 @@ fn http_trigger_env_config() -> HttpTriggerEnvConfig {
     HttpTriggerEnvConfig {
         listen: env::var(constants::SPIN_HTTP_LISTEN_ADDR_ENV)
             .unwrap_or_else(|_| constants::SPIN_ADDR_DEFAULT.to_string()),
-        idle_instance_timeout: env::var(constants::SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_ENV).ok(),
+        idle_instance_timeout: env::var(constants::SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_ENV)
+            .unwrap_or_else(|_| constants::SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_DEFAULT.to_string()),
         max_instance_reuse_count: env::var(constants::SPIN_HTTP_MAX_INSTANCE_REUSE_COUNT_ENV).ok(),
         max_instance_concurrent_reuse_count: env::var(
             constants::SPIN_HTTP_MAX_INSTANCE_CONCURRENT_REUSE_COUNT_ENV,
@@ -247,15 +248,15 @@ fn build_http_cli_args() -> Result<spin_trigger_http::CliArgs> {
 
     let config = http_trigger_env_config();
 
-    // Pass --listen explicitly so the shim default (0.0.0.0:80) takes precedence
-    // over spin's default (127.0.0.1:3000).
+    // Pass --listen and --idle-instance-timeout explicitly so shim defaults take
+    // precedence over spin's defaults
     let mut argv = vec![
         "spin-http-trigger".to_string(),
         format!("--listen={}", config.listen),
+        format!("--idle-instance-timeout={}", config.idle_instance_timeout),
     ];
 
     for (val, flag) in [
-        (config.idle_instance_timeout, "--idle-instance-timeout"),
         (
             config.max_instance_reuse_count,
             "--max-instance-reuse-count",

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, env, hash::Hash};
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use containerd_shim_wasm::{
     sandbox::{
         context::{RuntimeContext, WasmLayer},
@@ -28,7 +29,7 @@ use crate::{
     },
     utils::{
         configure_application_variables_from_environment_variables, initialize_cache,
-        is_wasm_content, parse_addr,
+        is_wasm_content,
     },
 };
 
@@ -170,22 +171,7 @@ impl SpinSandbox {
             let app = spin_app::App::new(app_id.clone(), app.clone());
             let f = match trigger_type.as_str() {
                 HTTP_TRIGGER_TYPE => {
-                    let address_str = env::var(constants::SPIN_HTTP_LISTEN_ADDR_ENV)
-                        .unwrap_or_else(|_| constants::SPIN_ADDR_DEFAULT.to_string());
-                    let address = parse_addr(&address_str)?;
-                    let cli_args = spin_trigger_http::CliArgs {
-                        address,
-                        tls_cert: None,
-                        tls_key: None,
-                        find_free_port: false,
-                        http1_max_buf_size: None,
-                        max_instance_reuse_count: None,
-                        max_instance_concurrent_reuse_count: None,
-                        request_timeout: None,
-                        idle_instance_timeout: spin_trigger_http::Range::Value(
-                            std::time::Duration::from_secs(1),
-                        ),
-                    };
+                    let cli_args = build_http_cli_args()?;
                     trigger::run::<HttpTrigger>(cli_args, app, &loader).await?
                 }
                 REDIS_TRIGGER_TYPE => trigger::run::<RedisTrigger>(NoCliArgs, app, &loader).await?,
@@ -222,6 +208,69 @@ impl SpinSandbox {
 
         result
     }
+}
+
+/// HTTP trigger configuration read from environment variables.
+struct HttpTriggerEnvConfig {
+    listen: String,
+    idle_instance_timeout: Option<String>,
+    max_instance_reuse_count: Option<String>,
+    max_instance_concurrent_reuse_count: Option<String>,
+    request_timeout: Option<String>,
+}
+
+/// Reads all HTTP trigger configuration from environment variables, falling back to
+/// shim defaults where applicable.
+fn http_trigger_env_config() -> HttpTriggerEnvConfig {
+    HttpTriggerEnvConfig {
+        listen: env::var(constants::SPIN_HTTP_LISTEN_ADDR_ENV)
+            .unwrap_or_else(|_| constants::SPIN_ADDR_DEFAULT.to_string()),
+        idle_instance_timeout: env::var(constants::SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_ENV).ok(),
+        max_instance_reuse_count: env::var(constants::SPIN_HTTP_MAX_INSTANCE_REUSE_COUNT_ENV).ok(),
+        max_instance_concurrent_reuse_count: env::var(
+            constants::SPIN_HTTP_MAX_INSTANCE_CONCURRENT_REUSE_COUNT_ENV,
+        )
+        .ok(),
+        request_timeout: env::var(constants::SPIN_HTTP_REQUEST_TIMEOUT_ENV).ok(),
+    }
+}
+
+/// Builds [`spin_trigger_http::CliArgs`] from the HTTP trigger environment configuration.
+///
+/// Values support the same formats as the CLI flags, including range syntax and duration. 
+fn build_http_cli_args() -> Result<spin_trigger_http::CliArgs> {
+    #[derive(Parser)]
+    struct HttpArgsParser {
+        #[clap(flatten)]
+        inner: spin_trigger_http::CliArgs,
+    }
+
+    let config = http_trigger_env_config();
+
+    // Pass --listen explicitly so the shim default (0.0.0.0:80) takes precedence
+    // over spin's default (127.0.0.1:3000).
+    let mut argv = vec![
+        "spin-http-trigger".to_string(),
+        format!("--listen={}", config.listen),
+    ];
+
+    for (val, flag) in [
+        (config.idle_instance_timeout, "--idle-instance-timeout"),
+        (config.max_instance_reuse_count, "--max-instance-reuse-count"),
+        (
+            config.max_instance_concurrent_reuse_count,
+            "--max-instance-concurrent-reuse-count",
+        ),
+        (config.request_timeout, "--request-timeout"),
+    ] {
+        if let Some(v) = val {
+            argv.push(format!("{flag}={v}"));
+        }
+    }
+
+    HttpArgsParser::try_parse_from(argv)
+        .map(|a| a.inner)
+        .map_err(|e| anyhow::anyhow!("invalid HTTP trigger configuration: {e}"))
 }
 
 impl Compiler for SpinCompiler {

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -237,7 +237,7 @@ fn http_trigger_env_config() -> HttpTriggerEnvConfig {
 
 /// Builds [`spin_trigger_http::CliArgs`] from the HTTP trigger environment configuration.
 ///
-/// Values support the same formats as the CLI flags, including range syntax and duration. 
+/// Values support the same formats as the CLI flags, including range syntax and duration.
 fn build_http_cli_args() -> Result<spin_trigger_http::CliArgs> {
     #[derive(Parser)]
     struct HttpArgsParser {
@@ -256,7 +256,10 @@ fn build_http_cli_args() -> Result<spin_trigger_http::CliArgs> {
 
     for (val, flag) in [
         (config.idle_instance_timeout, "--idle-instance-timeout"),
-        (config.max_instance_reuse_count, "--max-instance-reuse-count"),
+        (
+            config.max_instance_reuse_count,
+            "--max-instance-reuse-count",
+        ),
         (
             config.max_instance_concurrent_reuse_count,
             "--max-instance-concurrent-reuse-count",

--- a/containerd-shim-spin/src/utils.rs
+++ b/containerd-shim-spin/src/utils.rs
@@ -1,10 +1,9 @@
 use std::{
     env,
-    net::{SocketAddr, ToSocketAddrs},
     path::PathBuf,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use containerd_shim_wasm::sandbox::context::WasmLayer;
 use oci_spec::image::MediaType;
 use spin_app::locked::LockedApp;
@@ -53,14 +52,6 @@ pub(crate) fn is_wasm_content(layer: &WasmLayer) -> Option<WasmLayer> {
         }
     }
     None
-}
-
-pub(crate) fn parse_addr(addr: &str) -> Result<SocketAddr> {
-    let addrs: SocketAddr = addr
-        .to_socket_addrs()?
-        .next()
-        .ok_or_else(|| anyhow!("could not parse address: {addr}"))?;
-    Ok(addrs)
 }
 
 // For each Spin app variable, checks if a container environment variable with
@@ -128,13 +119,6 @@ mod tests {
                 assert!(env::var("SHOULD_BE_PREFIXED").is_ok());
             },
         );
-    }
-
-    #[test]
-    fn can_parse_spin_address() {
-        let parsed = parse_addr(constants::SPIN_ADDR_DEFAULT).unwrap();
-        assert_eq!(parsed.clone().port(), 80);
-        assert_eq!(parsed.ip().to_string(), "0.0.0.0");
     }
 
     #[test]


### PR DESCRIPTION
Configurable idle instance timeout (`SPIN_HTTP_IDLE_INSTANCE_TIMEOUT_SECS`):

The HTTP trigger keeps a component instance alive for this many seconds after handling a request.
Previously hardcoded to 1 s.
**Increase this on pods with bursty or low-frequency traffic to avoid repeated cold starts.**