### PR TITLE
fix(cross): build libseccomp from source, drop jorgeprendes420 images

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -1,25 +1,29 @@
 ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
 
-# Install Alpine's `apk` to be able to install musl packages
-COPY --from=jorgeprendes420/apk-anywhere / /
-ENV MARCH=${CROSS_CMAKE_SYSTEM_PROCESSOR}
-RUN apk-init ${MARCH} ${CROSS_SYSROOT}
+# Build libseccomp from source against the musl sysroot.
+# libseccomp-rs requires a static musl-linked libseccomp; we compile it here
+# using the cross-rs musl toolchain so we don't depend on any third-party images.
+RUN apt-get -y update && \
+    apt-get install -y pkg-config protobuf-compiler gperf curl && \
+    curl -fsSL https://github.com/seccomp/libseccomp/releases/download/v2.5.3/libseccomp-2.5.3.tar.gz \
+        -o /tmp/libseccomp.tar.gz && \
+    tar xf /tmp/libseccomp.tar.gz -C /tmp && \
+    cd /tmp/libseccomp-2.5.3 && \
+    ./configure \
+        --host=${CROSS_CMAKE_SYSTEM_PROCESSOR}-linux-musl \
+        CC=${CROSS_TOOLCHAIN_PREFIX}gcc \
+        --prefix=${CROSS_SYSROOT} \
+        --disable-shared \
+        --enable-static && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/libseccomp*
 
-# configure libsecccomp-rs to use static linking
-RUN apk-${MARCH} add libseccomp-static libseccomp-dev
+# configure libseccomp-rs to use static linking against the musl sysroot
 ENV LIBSECCOMP_LINK_TYPE="static"
 ENV LIBSECCOMP_LIB_PATH="${CROSS_SYSROOT}/lib"
-
-# wws needs zlib (though libssh2-sys)
-RUN apk-${MARCH} add zlib-dev zlib-static
-
-# See https://github.com/fermyon/spin/issues/1786 for the upstream issue requiring this polyfill.
-RUN --mount=type=bind,from=jorgeprendes420/gcc_vld1q_s8_x4_polyfill,source=/polyfill.sh,target=/polyfill.sh /polyfill.sh
 
 ## as per analysis done in https://github.com/fermyon/spin/pull/2287#issuecomment-1970145410 we need
 ## to disable the cmake config in cross-rs. Setting CROSS_SYSROOT=/ seems to have done the trick
 ENV CROSS_SYSROOT=/
-
-RUN apt-get -y update && \
-    apt-get install -y pkg-config protobuf-compiler


### PR DESCRIPTION
The jorgeprendes420/apk-anywhere and jorgeprendes420/gcc_vld1q_s8_x4_polyfill images are no longer accessible on Docker Hub, breaking cross-compilation.

Replace the apk-anywhere approach with building libseccomp 2.5.3 directly from source using the musl cross-compiler already present in the cross-rs base images. The gcc_vld1q_s8_x4_polyfill is no longer needed since ring 0.17.x uses pregenerated ASM that does not trigger the missing intrinsic.