### PR TITLE
chore: compilation with sccache

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,12 @@
 [build]
 default-target = "x86_64-unknown-linux-musl"
 
+[build.env]
+passthrough = [
+    "SCCACHE_ERROR_LOG",
+    "SCCACHE_LOG",
+]
+
 [target.x86_64-unknown-linux-musl]
 dockerfile = "./cross/Dockerfile"
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ BIN_DIR ?=
 
 UNAME_S := $(shell uname -s)
 
+SCCACHE_HOST_DIR ?= $(HOME)/.cache/sccache
+CROSS_CONTAINER_OPTS ?= -v $(SCCACHE_HOST_DIR):/tmp/sccache
+
 export
 
 

--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -1,6 +1,9 @@
 ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
 
+ARG SCCACHE_VERSION
+ARG SCCACHE_DIR
+
 # Build libseccomp from source against the musl sysroot.
 # libseccomp-rs requires a static musl-linked libseccomp; we compile it here
 # using the cross-rs musl toolchain so we don't depend on any third-party images.
@@ -27,3 +30,10 @@ ENV LIBSECCOMP_LIB_PATH="${CROSS_SYSROOT}/lib"
 ## as per analysis done in https://github.com/fermyon/spin/pull/2287#issuecomment-1970145410 we need
 ## to disable the cmake config in cross-rs. Setting CROSS_SYSROOT=/ seems to have done the trick
 ENV CROSS_SYSROOT=/
+
+# Install sccache for build caching inside the cross container.
+COPY cross/sccache.sh /
+RUN /sccache.sh "$(uname -m)-unknown-linux-musl"
+ENV RUSTC_WRAPPER="/usr/bin/sccache"
+ENV SCCACHE_DIR=${SCCACHE_DIR:-/tmp/sccache}
+RUN mkdir -p ${SCCACHE_DIR} "/.cache/sccache" && chmod 777 ${SCCACHE_DIR} "/.cache/sccache"

--- a/cross/sccache.sh
+++ b/cross/sccache.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+target="${1:?Usage: sccache.sh <target-triple>}"
+
+SCCACHE_VERSION="v0.8.2"
+url="https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${target}.tar.gz"
+
+echo "Installing sccache ${SCCACHE_VERSION} for ${target}..."
+curl -fsSL "${url}" -o /tmp/sccache.tar.gz
+tar xf /tmp/sccache.tar.gz -C /tmp
+install -m 755 "/tmp/sccache-${SCCACHE_VERSION}-${target}/sccache" /usr/bin/sccache
+rm -rf /tmp/sccache*
+
+echo "sccache installed: $(sccache --version)"


### PR DESCRIPTION
Adding support for `sccache` to reduce compilation time:
- `sscache` binary installed in cross image
- `sscache` env variables passed to cross image

tested by updating rust toolchain from `1.91.0` to `1.91.1` and then reversed that changes. 