### PR TITLE
chore: bump dependencies for Spin v4.0

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Run integration tests
         run: BIN_DIR="./bin" IS_CI=true make integration-tests
 
+      - name: Debug failed workloads
+        if: failure()
+        run: kubectl describe pods
+
       - name: Collect debug logs
         if: failure()
         run: make tests/collect-debug-logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -110,9 +110,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -376,21 +376,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auditable-serde"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
+
+[[package]]
+name = "auditable-serde"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d026218ae25ba5c72834245412dd1338f6d270d2c5109ee03a4badec288d4056"
 dependencies = [
  "semver",
  "serde",
@@ -1357,6 +1358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,75 +1426,37 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.55",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 1.0.0",
+ "clap_lex",
  "strsim 0.11.1",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1881,36 +1850,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b242b4c3675139f52f0b55624fb92571551a344305c5998f55ad20fa527bc55"
+checksum = "046d4b584c3bb9b5eb500c8f29549bec36be11000f1ba2a927cef3d1a9875691"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499715f19799219f32641b14f2a162f91e50bc1b61c2d2184c2be971716f5c56"
+checksum = "b9b194a7870becb1490366fc0ae392ccd188065ff35f8391e77ac659db6fb977"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebca2ea7c62c56feb88a5b23ec380460fe6d7c18134520f6ddf4bfa35cbea68"
+checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe11f154b62d7421d909503a746e89995393b1b71926e6f12b08a2076396d7fb"
+checksum = "b8b7a44150c2f471a94023482bda1902710746e4bed9f9973d60c5a94319b06d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1919,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2d0da3d51979dc0183fac3076a535477eab794716b063143ecb16632408664"
+checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1933,7 +1903,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "libm",
  "log",
  "pulley-interpreter",
@@ -1947,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483b2c94a1b7f6fba0714387ba34ca56d114b2214a80be018acbb2ed40e09a1e"
+checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1960,24 +1930,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4aae718c336a52d90d4ebe9a2d8c3cf0906a4bee78f0e6867e777eebbe554fe"
+checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18e94519070dc56cddb71906a08cea6a28a1d7c58ed501b88f273fa6b45fa07"
+checksum = "803159df35cc398ae54473c150b16d6c77e92ab2948be638488de126a3328fbc"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ab4e0eff1045ff2f5ddd8195bf3c97d7b5ef9b780cb044e0cce76e4d352057"
+checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1987,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7645a236e1ec49e660f09ec9fa979a1c5d0b612c419db7610573d4d58a03b7c"
+checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1999,15 +1969,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e0b4a1a0ea01cc19084ff01aaeb640dfe22905d47d83037a419b81ba587ed0"
+checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
 
 [[package]]
 name = "cranelift-native"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdec40b396eb630ecfb0e7a81766d7287f464a7631b9eb5862f7711f1020012"
+checksum = "373ade56438e6232619d85678477d0a88a31b3581936e0503e61e96b546b0800"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2016,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.129.2"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a001a9dc4557d9e2be324bc932621c0aa9bf33b74dfefa2338f0bf8913329"
+checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
 
 [[package]]
 name = "crc32fast"
@@ -2894,6 +2864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,7 +3144,7 @@ checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -3230,7 +3206,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3249,7 +3225,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3283,7 +3259,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
 
@@ -3292,6 +3268,22 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -3331,15 +3323,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -3817,12 +3800,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -3975,6 +3958,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if 1.0.4",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4040,7 +4067,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4246,7 +4273,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cc",
  "fallible-iterator 0.3.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "phf 0.11.3",
@@ -4272,7 +4299,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58"
 dependencies = [
- "clap 4.5.60",
+ "clap",
  "escape8259",
  "termcolor",
  "threadpool",
@@ -4818,7 +4845,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4867,13 +4894,13 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -5272,12 +5299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5512,7 +5533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5522,7 +5543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5650,7 +5671,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if 1.0.4",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -5789,30 +5810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -6170,9 +6167,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59a11b64c166a6e1e990303f46a255a52fb4e84d175dbd5e5ca0428e8c02ce"
+checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -6182,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823a9d8da391be21a5f4d5e11c39d15f45b011076c6825fc2323f7e4753f09ce"
+checksum = "ad360c32e85ca4b083ac0e2b6856e8f11c3d5060dafa7d5dc57b370857fa3018"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6248,9 +6245,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6509,13 +6506,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.5"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
  "smallvec",
@@ -7035,6 +7032,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7129,7 +7153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars_derive",
  "semver",
  "serde",
@@ -7440,7 +7464,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -7467,7 +7491,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -7670,6 +7694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7680,8 +7713,8 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "serde",
@@ -7690,11 +7723,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin-common"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+name = "spin-capabilities"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
+ "wac-graph",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "spin-common"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+dependencies = [
+ "anyhow",
+ "clap",
  "dirs 6.0.0",
  "sha2",
  "tempfile",
@@ -7704,28 +7749,29 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "tracing",
- "wasm-encoder 0.244.0",
- "wasm-metadata 0.244.0",
- "wasmparser 0.244.0",
- "wit-component 0.244.0",
- "wit-parser 0.244.0",
+ "wasm-encoder 0.247.0",
+ "wasm-metadata 0.247.0",
+ "wasmparser 0.247.0",
+ "wit-component 0.247.0",
+ "wit-parser 0.247.0",
 ]
 
 [[package]]
 name = "spin-compose"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
  "spin-app",
+ "spin-capabilities",
  "spin-common",
  "spin-componentize",
  "spin-serde",
@@ -7736,8 +7782,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7747,8 +7793,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7759,8 +7805,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-key-value"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "serde",
@@ -7770,18 +7816,18 @@ dependencies = [
  "spin-locked-app",
  "spin-resource-table",
  "spin-telemetry",
+ "spin-wasi-async",
  "spin-world",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
  "tracing",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-llm"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7796,16 +7842,15 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "url",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-otel"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "opentelemetry 0.28.0",
  "opentelemetry-otlp 0.28.0",
  "opentelemetry_sdk 0.28.0",
@@ -7816,13 +7861,12 @@ dependencies = [
  "spin-world",
  "tracing",
  "tracing-opentelemetry 0.29.0",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-outbound-http"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7845,6 +7889,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "tracing",
+ "tracing-opentelemetry 0.29.0",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -7852,8 +7897,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mqtt"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "rumqttc 0.24.0",
@@ -7865,13 +7910,12 @@ dependencies = [
  "spin-world",
  "tokio",
  "tracing",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-outbound-mysql"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "futures",
@@ -7885,13 +7929,12 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -7899,6 +7942,7 @@ dependencies = [
  "ip_network",
  "rustls 0.23.37",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "spin-factor-variables",
  "spin-factor-wasi",
@@ -7914,8 +7958,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-pg"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7928,23 +7972,27 @@ dependencies = [
  "postgres_range",
  "rust_decimal",
  "serde_json",
+ "spin-common",
  "spin-core",
  "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factors",
+ "spin-locked-app",
  "spin-resource-table",
+ "spin-wasi-async",
  "spin-world",
  "tokio",
  "tokio-postgres",
+ "tokio-rustls 0.26.4",
  "tracing",
+ "url",
  "uuid",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-outbound-redis"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "redis 0.32.7",
@@ -7956,43 +8004,43 @@ dependencies = [
  "spin-world",
  "tokio",
  "tracing",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-sqlite"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "async-trait",
+ "spin-core",
  "spin-factor-otel",
  "spin-factors",
  "spin-locked-app",
  "spin-resource-table",
+ "spin-wasi-async",
  "spin-world",
  "tokio",
  "tracing",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-variables"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
+ "spin-core",
  "spin-expressions",
  "spin-factor-otel",
  "spin-factors",
  "spin-telemetry",
  "spin-world",
  "tracing",
- "wasmtime",
 ]
 
 [[package]]
 name = "spin-factor-wasi"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8005,8 +8053,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "serde",
@@ -8019,8 +8067,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-derive"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8029,8 +8077,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-executor"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "spin-app",
@@ -8043,14 +8091,14 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "http 1.4.0",
  "http-body-util",
  "hyper 1.8.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "percent-encoding",
  "routefinder",
  "serde",
@@ -8066,11 +8114,11 @@ dependencies = [
 
 [[package]]
 name = "spin-http-routes"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "percent-encoding",
  "routefinder",
  "serde",
@@ -8079,8 +8127,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-aws"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -8090,12 +8138,13 @@ dependencies = [
  "serde",
  "spin-core",
  "spin-factor-key-value",
+ "tokio",
 ]
 
 [[package]]
 name = "spin-key-value-azure"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8106,12 +8155,13 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "spin-factor-key-value",
+ "tokio",
 ]
 
 [[package]]
 name = "spin-key-value-redis"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "redis 0.32.7",
@@ -8124,22 +8174,23 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-spin"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "rusqlite",
  "serde",
  "spin-core",
  "spin-factor-key-value",
+ "spin-wasi-async",
  "spin-world",
  "tokio",
 ]
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "futures",
@@ -8153,8 +8204,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -8182,8 +8233,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8196,11 +8247,11 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.8.22",
  "semver",
  "serde",
@@ -8214,8 +8265,8 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8241,14 +8292,14 @@ dependencies = [
  "tokio-util",
  "tracing",
  "walkdir",
- "wasmparser 0.244.0",
+ "wasmparser 0.247.0",
  "wat",
 ]
 
 [[package]]
 name = "spin-outbound-networking-config"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -8263,13 +8314,13 @@ dependencies = [
 
 [[package]]
 name = "spin-resource-table"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 
 [[package]]
 name = "spin-runtime-config"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "serde",
@@ -8303,11 +8354,11 @@ dependencies = [
 
 [[package]]
 name = "spin-runtime-factors"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "spin-common",
  "spin-factor-key-value",
  "spin-factor-llm",
@@ -8332,8 +8383,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8345,8 +8396,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "serde",
  "spin-factor-sqlite",
@@ -8358,21 +8409,23 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "rusqlite",
  "spin-factor-sqlite",
+ "spin-wasi-async",
  "spin-world",
  "tokio",
 ]
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8384,8 +8437,8 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -8402,13 +8455,14 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "ctrlc",
  "futures",
+ "heck 0.5.0",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -8430,11 +8484,11 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "futures",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -8470,8 +8524,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "futures",
@@ -8488,8 +8542,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-azure"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "azure_core 0.20.0",
  "azure_identity 0.20.0",
@@ -8503,8 +8557,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-env"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "dotenvy",
  "serde",
@@ -8517,8 +8571,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-static"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "serde",
  "serde_json",
@@ -8530,8 +8584,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-vault"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "serde",
  "spin-expressions",
@@ -8541,9 +8595,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-wasi-async"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+dependencies = [
+ "anyhow",
+ "spin-core",
+ "tokio",
+]
+
+[[package]]
 name = "spin-world"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8840,10 +8904,20 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "3.6.3"
-source = "git+https://github.com/spinframework/spin?tag=v3.6.3#88d51cf1dafa23c4177f5fbf122b3beca46d1941"
+version = "4.0.0"
+source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
 dependencies = [
  "termcolor",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8858,12 +8932,6 @@ dependencies = [
  "temp-dir",
  "tokio",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -9152,7 +9220,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -9165,7 +9233,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -9180,7 +9248,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 1.0.0+spec-1.1.0",
@@ -9222,7 +9290,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -9236,7 +9304,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -9532,11 +9600,11 @@ dependencies = [
 
 [[package]]
 name = "trigger-command"
-version = "0.5.3"
-source = "git+https://github.com/spinframework/spin-trigger-command?tag=v0.5.3#551fd55221f9b15be64a4a6003dfb15234a7025f"
+version = "0.6.0"
+source = "git+https://github.com/spinframework/spin-trigger-command?tag=v0.6.0#9930353c12e4a42d5be41c64ec5461db336cfaee"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "openssl",
  "serde",
  "spin-core",
@@ -9552,11 +9620,11 @@ dependencies = [
 
 [[package]]
 name = "trigger-mqtt"
-version = "0.7.2"
-source = "git+https://github.com/spinframework/spin-trigger-mqtt?tag=v0.7.2#4ecebd4e00d5b048828fc2681db398312cbe74e4"
+version = "0.8.0"
+source = "git+https://github.com/spinframework/spin-trigger-mqtt?tag=v0.8.0#3e57699441936c96bc025a81c07e9086c54bce31"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "futures",
  "paho-mqtt",
  "serde",
@@ -9575,13 +9643,13 @@ dependencies = [
 
 [[package]]
 name = "trigger-sqs"
-version = "0.12.2"
-source = "git+https://github.com/spinframework/spin-trigger-sqs?tag=v0.12.2#fc7e1fc14a603c2c3004134b8628791c522b5ba6"
+version = "0.13.0"
+source = "git+https://github.com/spinframework/spin-trigger-sqs?tag=v0.13.0#987f9722e353f18c955c614bb9daf47385530132"
 dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-sqs",
- "clap 3.2.25",
+ "clap",
  "futures",
  "openssl",
  "rustls 0.23.37",
@@ -9858,35 +9926,35 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wac-graph"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d511e0c9462a5f6369e7e17e9f0f3b566eab2a235076a23f2db19ca7bf36d32c"
+checksum = "1294c33de03c933cceedb23457c9317ca87b3df11580250ec35a6fadc8c229da"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "petgraph 0.6.5",
  "semver",
  "thiserror 1.0.69",
  "wac-types",
- "wasm-encoder 0.239.0",
- "wasm-metadata 0.239.0",
- "wasmparser 0.239.0",
+ "wasm-encoder 0.247.0",
+ "wasm-metadata 0.247.0",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
 name = "wac-types"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fdef742a5198856c7c754944b329ed684f703dca477d0a77b474b37d990121"
+checksum = "f8d2a240ab5ee560f160b161886e53b7eded2d5a9949964c832edfa1636f283b"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -9920,7 +9988,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98505d42b5289563c6d659f625b6789a97980166508bd00862c4328bf41c261"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.12.1",
  "serde",
  "serde_with",
@@ -9939,11 +10007,11 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bytes",
- "clap 4.5.60",
+ "clap",
  "dialoguer",
  "dirs 5.0.1",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.12.1",
  "keyring",
  "libc",
@@ -10024,7 +10092,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pbjson-types",
  "prost 0.12.6",
  "prost-types 0.12.6",
@@ -10045,7 +10113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8d8110b6800c43422676201a6a62167769b015ca29a8fcab67d789ac8b9c63"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prost 0.12.6",
  "thiserror 1.0.69",
  "warg-crypto",
@@ -10168,7 +10236,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "im-rc",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "petgraph 0.6.5",
  "serde",
@@ -10182,22 +10250,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.244.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cda9c76ca8dcac01a8b497860c2cb15cd6f216dc07060517df5abbe82512ac"
+checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "im-rc",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "petgraph 0.6.5",
  "serde",
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wat",
 ]
 
@@ -10233,16 +10301,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
@@ -10262,17 +10320,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c93c9e49fa2749be3c5ab28ad4be03167294915cd3b2ded3f04f760cef5cfb86"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
- "spdx",
+ "spdx 0.10.9",
  "url",
  "wasm-encoder 0.224.1",
  "wasmparser 0.224.1",
@@ -10285,35 +10353,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b055604ba04189d54b8c0ab2c2fc98848f208e103882d5c0b984f045d5ea4d20"
 dependencies = [
  "anyhow",
- "auditable-serde",
+ "auditable-serde 0.8.0",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
- "spdx",
+ "spdx 0.10.9",
  "url",
  "wasm-encoder 0.235.0",
  "wasmparser 0.235.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
-dependencies = [
- "anyhow",
- "auditable-serde",
- "flate2",
- "indexmap 2.13.0",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "url",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
 ]
 
 [[package]]
@@ -10323,16 +10372,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "auditable-serde",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665fe59e56cc9b419ca6fcca56673e3421d1a5011e3b65caf6b726fd9e041d10"
+dependencies = [
+ "anyhow",
+ "auditable-serde 0.9.0",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
- "spdx",
+ "spdx 0.13.4",
  "url",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -10410,7 +10471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -10422,7 +10483,7 @@ checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -10434,7 +10495,7 @@ checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -10447,21 +10508,8 @@ checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
- "serde",
 ]
 
 [[package]]
@@ -10472,9 +10520,8 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -10484,8 +10531,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -10500,20 +10562,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.244.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
+checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.244.0",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66806cf6094768e227f74d209eb017cc967276c94fea478e62a0dffede2b3d0d"
+checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -10544,9 +10606,9 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasm-compose 0.244.0",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-compose 0.245.1",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -10565,17 +10627,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d3611be7991cba09f14dbb99fe7a0fbaca9eb995ab5c548456eeda44afe20e"
+checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
 dependencies = [
  "anyhow",
  "cpp_demangle",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "log",
  "object",
  "postcard",
@@ -10583,20 +10646,21 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
- "wasmprinter 0.244.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
+ "wasmprinter 0.245.1",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2407af12566ff8d537b1a978eccaa087cc4c6d1f13fa57d21114a8def8bfe8a3"
+checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -10614,9 +10678,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3616cebe594e6c4b573ddb908d2703d13b53b2abdaeb73acd1ca8b5a911bc256"
+checksum = "0d3d6914f34be2f9d78d8ee9f422e834dfc204e71ccce697205fae95fed87892"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -10624,30 +10688,32 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.244.0",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61571112f9cbf9798e48f3bd6ba5161588a08b99158585153784e3f46f955053"
+checksum = "3751b0616b914fdd87fe1bf804694a078f321b000338e6476bc48a4d6e454f21"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7c68311d6220c20cefdf334e0c8021e16a050383c67edc5be42e5661ddf265"
+checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
 dependencies = [
  "anyhow",
+ "hashbrown 0.16.1",
  "libm",
+ "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fd90a9113379260508193bab9f4e870d34078fdd181f9fc8dd053b0f7a958c"
+checksum = "8b3ca07b3e0bb3429674b173b5800577719d600774dd81bff58f775c0aaa64ee"
 dependencies = [
  "cfg-if 1.0.4",
  "cranelift-codegen",
@@ -10663,7 +10729,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.244.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -10672,9 +10738,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd95ecd37e62eaae686256ca9773902b73c0398c2eb8cfbca49fbf950609c22"
+checksum = "20c8b2c9704eb1f33ead025ec16038277ccb63d0a14c31e99d5b765d7c36da55"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",
@@ -10687,9 +10753,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b875a7727c043a308c81f2de5ce7260b7513cb5baaa2af32937646b8c9019a3f"
+checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
 dependencies = [
  "cc",
  "object",
@@ -10699,9 +10765,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52c0779e711777b915d017b3f54049e658057a77df99e0e7958406b3c5d7d07"
+checksum = "3606662c156962d096be3127b8b8ae8ee2f8be3f896dad29259ff01ddb64abfd"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
@@ -10711,9 +10777,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb031b1e9700667b3f818235b2846e3babeb30bc340c8233d3fad4c44d80ff"
+checksum = "75eef0747e52dc545b075f64fd0e0cc237ae738e641266b1970e07e2d744bc32"
 dependencies = [
  "cfg-if 1.0.4",
  "cranelift-codegen",
@@ -10724,9 +10790,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbfbbfdb0cfd638145b0de4d3e309901ccc4e29965a33ca1eb18ab6f37057350"
+checksum = "d8b0a5dab02a8fb527f547855ecc0e05f9fdc3d5bd57b8b080349408f9a6cece"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10735,16 +10801,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4853af4a25f98c039cc27c7238e40df9ec783fc7981b879a813153d1d3211a"
+checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
 dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.244.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -10752,22 +10818,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de1c8eaa54b17e3a64b6c0cfabd065bdbdfd06f5d7c685272b7309117377be0"
+checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
  "heck 0.5.0",
- "indexmap 2.13.0",
- "wit-parser 0.244.0",
+ "indexmap 2.14.0",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e144a12c39adabd2ce1f7b52bd12a60286d3010044ed0d1c2ae52e35fd6f5ce"
+checksum = "ed3e3ddcfad69e9eb025bd19bff70dad45bafe1d6eacd134c0ffdfc4c161d045"
 dependencies = [
  "async-trait",
  "bitflags 2.11.0",
@@ -10795,9 +10861,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d74f0851af401e7b57f3b5af9352dfef2be04b1f2c3b6c5c92b4636c6503c88e"
+checksum = "2b286829e05b5d8559d9519f44451e82502739ef48689b66debe96612e2b88df"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10819,9 +10885,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609666ef67a53449ea6c1c529541a8af24f3b109d9f627255c0b848c58b824b0"
+checksum = "3ca5dd3b9f04a851c422d05f333366722742da46bff9369ae0191f32cf83565a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10882,6 +10948,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10936,9 +11011,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0bbdfe34fac0937e887fd0b3b9266b775c1fff8cd2e3f80ffa5d67b35bfa7cb"
+checksum = "cc1b1135efc8e5a008971897bea8d41ca56d8d501d4efb807842ae0a1c78f639"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -10950,9 +11025,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7316746ac77a917a33ccc0cee6794bd72e300f2f533c28b8d5738f1f5fa29f"
+checksum = "a7bc2b0d50ec8773b44fbfe1da6cb5cc44a92deaf8483233dcf0831e6db33172"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -10964,9 +11039,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f625d05adeddad85c8d5fbcd765a8ecf1b22260840a0a193125dc4ab06ac9d"
+checksum = "2d6c7d44ea552e1fbfdcd7a2cd83f5c2d1e803d5b1a11e3462c06888b77f455f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11007,9 +11082,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "42.0.2"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1bc7cbb9103e6847042f0514f911126263173f6e9a18e5cfa257d3b5711c09"
+checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -11018,7 +11093,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.244.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -11096,6 +11171,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -11137,6 +11221,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -11189,6 +11288,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -11207,6 +11312,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -11222,6 +11333,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11255,6 +11372,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -11270,6 +11393,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11291,6 +11420,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -11306,6 +11441,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11388,7 +11529,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata 0.244.0",
@@ -11419,7 +11560,7 @@ checksum = "923637fe647372efbbb654757f8c884ba280924477e1d265eca7e35d4cdcea8b"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -11438,7 +11579,7 @@ checksum = "64a57a11109cc553396f89f3a38a158a97d0b1adaec113bd73e0f64d30fb601f"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -11457,7 +11598,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -11469,6 +11610,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-component"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d567162a6b9843080e5e0053f696623ff694bae8ae017c9ec536d1873bbe3d8"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.247.0",
+ "wasm-metadata 0.247.0",
+ "wasmparser 0.247.0",
+ "wit-parser 0.247.0",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11476,7 +11636,7 @@ checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -11494,7 +11654,7 @@ checksum = "0a1f95a87d03a33e259af286b857a95911eb46236a0f726cbaec1227b3dfc67a"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -11512,7 +11672,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -11520,6 +11680,44 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
  "anyhow",
  "curl",
  "redis 1.0.4",
- "rumqttc 0.25.1",
+ "rumqttc 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 
@@ -1850,27 +1850,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046d4b584c3bb9b5eb500c8f29549bec36be11000f1ba2a927cef3d1a9875691"
+checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b194a7870becb1490366fc0ae392ccd188065ff35f8391e77ac659db6fb977"
+checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
+checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1878,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a44150c2f471a94023482bda1902710746e4bed9f9973d60c5a94319b06d"
+checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
+checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1917,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
+checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1930,24 +1930,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
+checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803159df35cc398ae54473c150b16d6c77e92ab2948be638488de126a3328fbc"
+checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
+checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1957,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
+checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1969,15 +1969,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
+checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373ade56438e6232619d85678477d0a88a31b3581936e0503e61e96b546b0800"
+checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.1"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
+checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
 
 [[package]]
 name = "crc32fast"
@@ -3549,6 +3549,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -4894,12 +4895,12 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"
-version = "0.38.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -5200,6 +5201,12 @@ dependencies = [
  "prost 0.13.5",
  "tonic 0.12.3",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -6167,9 +6174,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
+checksum = "dff0ead8b4616f81b3d3efd41ce41bcf9ea364a5d8df8be8a8a1f98b50104349"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -6179,9 +6186,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad360c32e85ca4b083ac0e2b6856e8f11c3d5060dafa7d5dc57b370857fa3018"
+checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6632,6 +6639,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6754,25 +6762,6 @@ dependencies = [
 
 [[package]]
 name = "rumqttc"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
-dependencies = [
- "bytes",
- "flume",
- "futures-util",
- "log",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
- "rustls-webpki 0.102.8",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls 0.25.0",
- "url",
-]
-
-[[package]]
-name = "rumqttc"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0feff8d882bff0b2fddaf99355a10336d43dd3ed44204f85ece28cf9626ab519"
@@ -6790,6 +6779,27 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.25.1"
+source = "git+https://github.com/spinframework/rumqtt?rev=65b7b39a70b12d1781acb61cc07f1f1b680e7643#65b7b39a70b12d1781acb61cc07f1f1b680e7643"
+dependencies = [
+ "bytes",
+ "fixedbitset 0.5.7",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.8.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-webpki 0.103.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -7148,20 +7158,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "indexmap 2.14.0",
- "schemars_derive",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -7179,16 +7175,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
+ "indexmap 2.14.0",
  "ref-cast",
+ "schemars_derive",
+ "semver",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7713,8 +7712,8 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "serde",
@@ -7724,8 +7723,8 @@ dependencies = [
 
 [[package]]
 name = "spin-capabilities"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "wac-graph",
@@ -7735,8 +7734,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "clap",
@@ -7749,8 +7748,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "tracing",
@@ -7763,8 +7762,8 @@ dependencies = [
 
 [[package]]
 name = "spin-compose"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7782,8 +7781,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7793,8 +7792,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7805,8 +7804,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-key-value"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "serde",
@@ -7826,8 +7825,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-llm"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7846,8 +7845,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-otel"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -7865,8 +7864,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-http"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7876,6 +7875,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "opentelemetry-semantic-conventions",
  "pin-project-lite",
  "reqwest 0.12.28",
  "rustls 0.23.37",
@@ -7897,11 +7897,11 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mqtt"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
- "rumqttc 0.24.0",
+ "rumqttc 0.25.1 (git+https://github.com/spinframework/rumqtt?rev=65b7b39a70b12d1781acb61cc07f1f1b680e7643)",
  "spin-core",
  "spin-factor-otel",
  "spin-factor-outbound-networking",
@@ -7914,8 +7914,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mysql"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "futures",
@@ -7925,6 +7925,8 @@ dependencies = [
  "spin-factor-outbound-networking",
  "spin-factors",
  "spin-resource-table",
+ "spin-telemetry",
+ "spin-wasi-async",
  "spin-world",
  "tokio",
  "tracing",
@@ -7933,13 +7935,14 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "futures-util",
  "http 1.4.0",
  "ip_network",
+ "opentelemetry-semantic-conventions",
  "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -7953,13 +7956,13 @@ dependencies = [
  "spin-serde",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-root-certs",
 ]
 
 [[package]]
 name = "spin-factor-outbound-pg"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7979,6 +7982,7 @@ dependencies = [
  "spin-factors",
  "spin-locked-app",
  "spin-resource-table",
+ "spin-telemetry",
  "spin-wasi-async",
  "spin-world",
  "tokio",
@@ -7991,8 +7995,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-redis"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "redis 0.32.7",
@@ -8008,8 +8012,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-sqlite"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "async-trait",
  "spin-core",
@@ -8025,8 +8029,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-variables"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "spin-core",
  "spin-expressions",
@@ -8039,8 +8043,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-wasi"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8053,8 +8057,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "serde",
@@ -8067,8 +8071,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-derive"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8077,8 +8081,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-executor"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "spin-app",
@@ -8091,8 +8095,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "http 1.4.0",
@@ -8114,8 +8118,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http-routes"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -8127,8 +8131,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-aws"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -8143,8 +8147,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8160,8 +8164,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "redis 0.32.7",
@@ -8174,8 +8178,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-spin"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -8189,8 +8193,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "futures",
@@ -8204,8 +8208,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -8233,8 +8237,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8247,12 +8251,12 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "semver",
  "serde",
  "spin-serde",
@@ -8265,8 +8269,8 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8298,8 +8302,8 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking-config"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -8314,13 +8318,13 @@ dependencies = [
 
 [[package]]
 name = "spin-resource-table"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 
 [[package]]
 name = "spin-runtime-config"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "serde",
@@ -8354,8 +8358,8 @@ dependencies = [
 
 [[package]]
 name = "spin-runtime-factors"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "clap",
@@ -8383,12 +8387,12 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "semver",
  "serde",
  "wasm-pkg-common",
@@ -8396,8 +8400,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "serde",
  "spin-factor-sqlite",
@@ -8409,8 +8413,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8424,8 +8428,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8437,8 +8441,8 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -8447,6 +8451,7 @@ dependencies = [
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp 0.28.0",
  "opentelemetry_sdk 0.28.0",
+ "reqwest 0.12.28",
  "terminal",
  "tracing",
  "tracing-opentelemetry 0.29.0",
@@ -8455,8 +8460,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "clap",
@@ -8484,8 +8489,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "clap",
@@ -8495,6 +8500,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "opentelemetry-semantic-conventions",
  "pin-project-lite",
  "rand 0.9.2",
  "rustls 0.23.37",
@@ -8524,8 +8530,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "futures",
@@ -8542,8 +8548,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-azure"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "azure_core 0.20.0",
  "azure_identity 0.20.0",
@@ -8557,8 +8563,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-env"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "dotenvy",
  "serde",
@@ -8571,8 +8577,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-static"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "serde",
  "serde_json",
@@ -8584,8 +8590,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-vault"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "serde",
  "spin-expressions",
@@ -8596,8 +8602,8 @@ dependencies = [
 
 [[package]]
 name = "spin-wasi-async"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "spin-core",
@@ -8606,8 +8612,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8904,8 +8910,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "4.0.0"
-source = "git+https://github.com/spinframework/spin?rev=5f3aa19c50d1609592f7ea2f6362209a04da52ac#5f3aa19c50d1609592f7ea2f6362209a04da52ac"
+version = "4.1.0-pre0"
+source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
 dependencies = [
  "termcolor",
 ]
@@ -9601,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "trigger-command"
 version = "0.6.0"
-source = "git+https://github.com/spinframework/spin-trigger-command?tag=v0.6.0#9930353c12e4a42d5be41c64ec5461db336cfaee"
+source = "git+https://github.com/kate-goldenring/spin-trigger-plugins?rev=cc5adc136365482e7135b330f787f6237a0a1388#cc5adc136365482e7135b330f787f6237a0a1388"
 dependencies = [
  "anyhow",
  "clap",
@@ -9621,11 +9627,12 @@ dependencies = [
 [[package]]
 name = "trigger-mqtt"
 version = "0.8.0"
-source = "git+https://github.com/spinframework/spin-trigger-mqtt?tag=v0.8.0#3e57699441936c96bc025a81c07e9086c54bce31"
+source = "git+https://github.com/kate-goldenring/spin-trigger-plugins?rev=cc5adc136365482e7135b330f787f6237a0a1388#cc5adc136365482e7135b330f787f6237a0a1388"
 dependencies = [
  "anyhow",
  "clap",
  "futures",
+ "openssl",
  "paho-mqtt",
  "serde",
  "spin-app",
@@ -9644,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "trigger-sqs"
 version = "0.13.0"
-source = "git+https://github.com/spinframework/spin-trigger-sqs?tag=v0.13.0#987f9722e353f18c955c614bb9daf47385530132"
+source = "git+https://github.com/kate-goldenring/spin-trigger-plugins?rev=cc5adc136365482e7135b330f787f6237a0a1388#cc5adc136365482e7135b330f787f6237a0a1388"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -10250,22 +10257,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
+checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "im-rc",
  "indexmap 2.14.0",
  "log",
  "petgraph 0.6.5",
- "serde",
- "serde_derive",
- "serde_yaml",
  "smallvec",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wat",
 ]
 
@@ -10311,12 +10314,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -10327,6 +10330,16 @@ checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.250.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2271adb766023046af314460f1fae02cc34ea16d736d93404d3b65be44270923"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.250.0",
 ]
 
 [[package]]
@@ -10526,9 +10539,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.16.1",
@@ -10551,6 +10564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.250.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071d99cdfb8111603ed05500506c3298a940b58d609dd0259d3981785dd33556"
+dependencies = [
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10562,20 +10586,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
+checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -10606,9 +10630,9 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasm-compose 0.245.1",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-compose 0.246.2",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -10627,9 +10651,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
+checksum = "7e84dbe3208c1336a41546beb75927b3b37e2e4fce06653d214b407136fbe295"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -10649,18 +10673,18 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
- "wasmprinter 0.245.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
+ "wasmprinter 0.246.2",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
+checksum = "910b8dcadc0888344b2dea5a087c836b58156d4f455c52b6dac0bdc776a9d029"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -10678,9 +10702,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d6914f34be2f9d78d8ee9f422e834dfc204e71ccce697205fae95fed87892"
+checksum = "c223bd503db76df8d74d1fcca39e734d25f7a0c1dcaf1509b67f3855d1b0f803"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -10688,20 +10712,20 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.245.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3751b0616b914fdd87fe1bf804694a078f321b000338e6476bc48a4d6e454f21"
+checksum = "ab123ad511483a1b918399789d0cc7dea7c5c6476743df73949007b5b225fc74"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
+checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -10711,9 +10735,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ca07b3e0bb3429674b173b5800577719d600774dd81bff58f775c0aaa64ee"
+checksum = "c5a3bc28a172037c7864128bb208017a02bba659a59c27acacc048c09e25c1fc"
 dependencies = [
  "cfg-if 1.0.4",
  "cranelift-codegen",
@@ -10729,7 +10753,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -10738,9 +10762,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c8b2c9704eb1f33ead025ec16038277ccb63d0a14c31e99d5b765d7c36da55"
+checksum = "3c90a899a47d3da6e384e7b4cad61fdcb27535a395742b32440bdf9980ea83fa"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",
@@ -10753,9 +10777,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
+checksum = "84f364747aa74c686b18925918e5cfd615a73c9613c7a31fc1cd86f42df12fbe"
 dependencies = [
  "cc",
  "object",
@@ -10765,9 +10789,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3606662c156962d096be3127b8b8ae8ee2f8be3f896dad29259ff01ddb64abfd"
+checksum = "c3ba98c1492f530833e0d3cc17dbb0c3c57c9f1bb3b078ae44bb55a233e43eba"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
@@ -10777,9 +10801,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75eef0747e52dc545b075f64fd0e0cc237ae738e641266b1970e07e2d744bc32"
+checksum = "94b8f8a89e8f3660646f820c7d8310a67094156bb866e9d56f1b00892e011206"
 dependencies = [
  "cfg-if 1.0.4",
  "cranelift-codegen",
@@ -10790,9 +10814,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b0a5dab02a8fb527f547855ecc0e05f9fdc3d5bd57b8b080349408f9a6cece"
+checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10801,16 +10825,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
+checksum = "4b06e4ed07adc579645e5c55c67b3138c49da2e468fad52d3db7b7a098ecc733"
 dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -10818,22 +10842,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
+checksum = "0f08787948e3c983799d616ef7dd57463253e9ca8bab6607eef8134f12353f70"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser 0.245.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3e3ddcfad69e9eb025bd19bff70dad45bafe1d6eacd134c0ffdfc4c161d045"
+checksum = "1b2f19834bc6edbc31ac95fdcfd5ddcd7643759265a1d545dec36ac6cc788ca8"
 dependencies = [
  "async-trait",
  "bitflags 2.11.0",
@@ -10861,9 +10885,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b286829e05b5d8559d9519f44451e82502739ef48689b66debe96612e2b88df"
+checksum = "7397d43b11cb9f30b6789dd5a76791d370a21b2f8099932c0e6e3e5b0a2584b6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10872,9 +10896,9 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "rustls 0.22.4",
+ "rustls 0.23.37",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tracing",
  "wasmtime",
@@ -10885,9 +10909,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca5dd3b9f04a851c422d05f333366722742da46bff9369ae0191f32cf83565a"
+checksum = "c3e0c6efdbaf90906016be9ed9ff17b7b58f393876287beebe5bd7fa1de54dbb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10907,24 +10931,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "250.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "69e9294a1f0204aeb5c47e95165517f43ef3cc895918c4f3e939380d4c290f4a"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.250.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.250.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "0a549ed329a70e444e0f7796391ab2a87d0aef30ddde9f60e16e429224fafd02"
 dependencies = [
- "wast 245.0.1",
+ "wast 250.0.0",
 ]
 
 [[package]]
@@ -11011,9 +11035,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1b1135efc8e5a008971897bea8d41ca56d8d501d4efb807842ae0a1c78f639"
+checksum = "17b644ab90da80bbca28973192978ac452cbd876955bb209e6ff2cd1955e43a7"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -11025,9 +11049,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bc2b0d50ec8773b44fbfe1da6cb5cc44a92deaf8483233dcf0831e6db33172"
+checksum = "521f9d558365357274d960340eb9eb4f4d768fafdc79f381fd2e13a85b925ebc"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -11039,9 +11063,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6c7d44ea552e1fbfdcd7a2cd83f5c2d1e803d5b1a11e3462c06888b77f455f"
+checksum = "8a386e86021363c9f0abd1e189e8f8a729d9b5aab2bb7172a3e40f2ab647a936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11082,9 +11106,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "43.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
+checksum = "f16496e92d2b232f9d195ae74f71a674aabae7b7fa722d39068836723d3b653c"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -11093,7 +11117,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -11684,9 +11708,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -11698,7 +11722,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,8 +7712,8 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "serde",
@@ -7723,8 +7723,8 @@ dependencies = [
 
 [[package]]
 name = "spin-capabilities"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "wac-graph",
@@ -7734,8 +7734,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "clap",
@@ -7748,8 +7748,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "tracing",
@@ -7762,8 +7762,8 @@ dependencies = [
 
 [[package]]
 name = "spin-compose"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7781,8 +7781,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7792,8 +7792,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7804,8 +7804,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-key-value"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "serde",
@@ -7825,8 +7825,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-llm"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7845,8 +7845,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-otel"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -7864,8 +7864,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-http"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7897,8 +7897,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mqtt"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "rumqttc 0.25.1 (git+https://github.com/spinframework/rumqtt?rev=65b7b39a70b12d1781acb61cc07f1f1b680e7643)",
@@ -7914,8 +7914,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mysql"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "futures",
@@ -7935,8 +7935,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -7961,8 +7961,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-pg"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7995,8 +7995,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-redis"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "redis 0.32.7",
@@ -8012,8 +8012,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-sqlite"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "async-trait",
  "spin-core",
@@ -8029,8 +8029,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-variables"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "spin-core",
  "spin-expressions",
@@ -8043,8 +8043,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-wasi"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8057,8 +8057,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "serde",
@@ -8071,8 +8071,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-derive"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8081,8 +8081,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-executor"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "spin-app",
@@ -8095,8 +8095,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "http 1.4.0",
@@ -8118,8 +8118,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http-routes"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -8131,8 +8131,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-aws"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -8147,8 +8147,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8164,8 +8164,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "redis 0.32.7",
@@ -8178,8 +8178,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-spin"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -8193,8 +8193,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "futures",
@@ -8208,8 +8208,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -8237,8 +8237,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8251,8 +8251,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -8269,8 +8269,8 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8302,8 +8302,8 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking-config"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -8318,13 +8318,13 @@ dependencies = [
 
 [[package]]
 name = "spin-resource-table"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 
 [[package]]
 name = "spin-runtime-config"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "serde",
@@ -8358,8 +8358,8 @@ dependencies = [
 
 [[package]]
 name = "spin-runtime-factors"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "clap",
@@ -8387,8 +8387,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8400,8 +8400,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "serde",
  "spin-factor-sqlite",
@@ -8413,8 +8413,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8428,8 +8428,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8441,8 +8441,8 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -8460,8 +8460,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "clap",
@@ -8489,8 +8489,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "clap",
@@ -8530,8 +8530,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "futures",
@@ -8548,8 +8548,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-azure"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "azure_core 0.20.0",
  "azure_identity 0.20.0",
@@ -8563,8 +8563,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-env"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "dotenvy",
  "serde",
@@ -8577,8 +8577,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-static"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "serde",
  "serde_json",
@@ -8590,8 +8590,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables-vault"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "serde",
  "spin-expressions",
@@ -8602,8 +8602,8 @@ dependencies = [
 
 [[package]]
 name = "spin-wasi-async"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "spin-core",
@@ -8612,8 +8612,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8910,8 +8910,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "4.1.0-pre0"
-source = "git+https://github.com/spinframework/spin?rev=658ea7bd076135b17b3ed72763eafd3fc7b08582#658ea7bd076135b17b3ed72763eafd3fc7b08582"
+version = "4.0.1"
+source = "git+https://github.com/spinframework/spin?tag=v4.0.1#5b09e1a93ef81a476ac866e62c954f10234d7ff8"
 dependencies = [
  "termcolor",
 ]
@@ -9606,8 +9606,8 @@ dependencies = [
 
 [[package]]
 name = "trigger-command"
-version = "0.6.0"
-source = "git+https://github.com/kate-goldenring/spin-trigger-plugins?rev=cc5adc136365482e7135b330f787f6237a0a1388#cc5adc136365482e7135b330f787f6237a0a1388"
+version = "0.7.0"
+source = "git+https://github.com/spinframework/spin-trigger-plugins?tag=command-v0.7.0#21937233ab3407e343afb7247d0738563ed5d2fb"
 dependencies = [
  "anyhow",
  "clap",
@@ -9626,8 +9626,8 @@ dependencies = [
 
 [[package]]
 name = "trigger-mqtt"
-version = "0.8.0"
-source = "git+https://github.com/kate-goldenring/spin-trigger-plugins?rev=cc5adc136365482e7135b330f787f6237a0a1388#cc5adc136365482e7135b330f787f6237a0a1388"
+version = "0.9.0"
+source = "git+https://github.com/spinframework/spin-trigger-plugins?tag=mqtt-v0.9.0#21937233ab3407e343afb7247d0738563ed5d2fb"
 dependencies = [
  "anyhow",
  "clap",
@@ -9650,8 +9650,8 @@ dependencies = [
 
 [[package]]
 name = "trigger-sqs"
-version = "0.13.0"
-source = "git+https://github.com/kate-goldenring/spin-trigger-plugins?rev=cc5adc136365482e7135b330f787f6237a0a1388#cc5adc136365482e7135b330f787f6237a0a1388"
+version = "0.14.0"
+source = "git+https://github.com/spinframework/spin-trigger-plugins?tag=sqs-v0.14.0#21937233ab3407e343afb7247d0738563ed5d2fb"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -13,24 +13,24 @@ Containerd shim for running Spin workloads.
 [dependencies]
 containerd-shim-wasm = { version = "1.0.0", default-features = false, features = ["opentelemetry"]}
 log = "0.4"
-spin-app = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-spin-componentize = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
+spin-app = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-componentize = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
 # Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/spinframework/spin", tag = "v3.6.3", features = [
+spin-trigger = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac", features = [
     "unsafe-aot-compilation",
 ] }
-spin-trigger-http = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-spin-trigger-redis = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-trigger-mqtt = { git = "https://github.com/spinframework/spin-trigger-mqtt", tag = "v0.7.2" } 
-trigger-sqs = { git = "https://github.com/spinframework/spin-trigger-sqs", tag = "v0.12.2" } 
-trigger-command = { git = "https://github.com/spinframework/spin-trigger-command", tag ="v0.5.3" } 
-spin-loader = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-spin-oci = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-spin-telemetry = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-spin-runtime-factors = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-spin-core = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin", tag = "v3.6.3" }
-wasmtime = "42.0.2"
+spin-trigger-http = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-trigger-redis = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+trigger-mqtt = { git = "https://github.com/spinframework/spin-trigger-mqtt", tag = "v0.8.0" } 
+trigger-sqs = { git = "https://github.com/spinframework/spin-trigger-sqs", tag = "v0.13.0" } 
+trigger-command = { git = "https://github.com/spinframework/spin-trigger-command", tag ="v0.6.0" } 
+spin-loader = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-oci = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-telemetry = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-runtime-factors = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-core = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+wasmtime = "43.0.1"
 openssl = { version = "*", features = ["vendored"] }
 anyhow = "1.0"
 oci-spec = "0.7"

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -13,24 +13,24 @@ Containerd shim for running Spin workloads.
 [dependencies]
 containerd-shim-wasm = { version = "1.0.0", default-features = false, features = ["opentelemetry"]}
 log = "0.4"
-spin-app = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-spin-componentize = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-app = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+spin-componentize = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
 # Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582", features = [
+spin-trigger = { git = "https://github.com/spinframework/spin", tag = "v4.0.1", features = [
     "unsafe-aot-compilation",
 ] }
-spin-trigger-http = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-spin-trigger-redis = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-trigger-mqtt = { git = "https://github.com/kate-goldenring/spin-trigger-plugins", rev = "cc5adc136365482e7135b330f787f6237a0a1388" } 
-trigger-sqs = { git = "https://github.com/kate-goldenring/spin-trigger-plugins", rev = "cc5adc136365482e7135b330f787f6237a0a1388" }
-trigger-command = { git = "https://github.com/kate-goldenring/spin-trigger-plugins", rev = "cc5adc136365482e7135b330f787f6237a0a1388" }
-spin-loader = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-spin-oci = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-spin-telemetry = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-spin-runtime-factors = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-spin-core = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
-wasmtime = "44"
+spin-trigger-http = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+spin-trigger-redis = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+trigger-mqtt = { git = "https://github.com/spinframework/spin-trigger-plugins", tag = "mqtt-v0.9.0" } 
+trigger-sqs = { git = "https://github.com/spinframework/spin-trigger-plugins", tag = "sqs-v0.14.0" }
+trigger-command = { git = "https://github.com/spinframework/spin-trigger-plugins", tag = "command-v0.7.0" }
+spin-loader = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+spin-oci = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+spin-telemetry = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+spin-runtime-factors = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+spin-core = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
+wasmtime = "44.0.0"
 openssl = { version = "*", features = ["vendored"] }
 anyhow = "1.0"
 oci-spec = "0.7"

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -13,24 +13,24 @@ Containerd shim for running Spin workloads.
 [dependencies]
 containerd-shim-wasm = { version = "1.0.0", default-features = false, features = ["opentelemetry"]}
 log = "0.4"
-spin-app = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-spin-componentize = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
+spin-app = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-componentize = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
 # Enable loading components precompiled by the shim
-spin-trigger = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac", features = [
+spin-trigger = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582", features = [
     "unsafe-aot-compilation",
 ] }
-spin-trigger-http = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-spin-trigger-redis = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-trigger-mqtt = { git = "https://github.com/spinframework/spin-trigger-mqtt", tag = "v0.8.0" } 
-trigger-sqs = { git = "https://github.com/spinframework/spin-trigger-sqs", tag = "v0.13.0" } 
-trigger-command = { git = "https://github.com/spinframework/spin-trigger-command", tag ="v0.6.0" } 
-spin-loader = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-spin-oci = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-spin-telemetry = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-spin-runtime-factors = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-spin-core = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin", rev = "5f3aa19c50d1609592f7ea2f6362209a04da52ac" }
-wasmtime = "43.0.1"
+spin-trigger-http = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-trigger-redis = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+trigger-mqtt = { git = "https://github.com/kate-goldenring/spin-trigger-plugins", rev = "cc5adc136365482e7135b330f787f6237a0a1388" } 
+trigger-sqs = { git = "https://github.com/kate-goldenring/spin-trigger-plugins", rev = "cc5adc136365482e7135b330f787f6237a0a1388" }
+trigger-command = { git = "https://github.com/kate-goldenring/spin-trigger-plugins", rev = "cc5adc136365482e7135b330f787f6237a0a1388" }
+spin-loader = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-oci = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-telemetry = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-runtime-factors = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-core = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin", rev = "658ea7bd076135b17b3ed72763eafd3fc7b08582" }
+wasmtime = "44"
 openssl = { version = "*", features = ["vendored"] }
 anyhow = "1.0"
 oci-spec = "0.7"

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -185,6 +185,7 @@ impl SpinSandbox {
                         idle_instance_timeout: spin_trigger_http::Range::Value(
                             std::time::Duration::from_secs(1),
                         ),
+                        format: spin_trigger_http::OutputFormat::default(),
                     };
                     trigger::run::<HttpTrigger>(cli_args, app, &loader).await?
                 }

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -159,6 +159,9 @@ impl SpinSandbox {
             // `spin registry push`
             Source::File(_) => {}
         };
+        // Box::leak gives a 'static reference. The loader lives for the process lifetime,
+        // which is fine since this function runs once per container invocation.
+        let loader: &'static _ = Box::leak(Box::new(loader));
 
         let mut futures_list = Vec::new();
         let mut trigger_type_map = Vec::new();
@@ -187,19 +190,19 @@ impl SpinSandbox {
                         ),
                         format: spin_trigger_http::OutputFormat::default(),
                     };
-                    trigger::run::<HttpTrigger>(cli_args, app, &loader).await?
+                    trigger::run::<HttpTrigger>(cli_args, app, loader).await?
                 }
-                REDIS_TRIGGER_TYPE => trigger::run::<RedisTrigger>(NoCliArgs, app, &loader).await?,
-                SQS_TRIGGER_TYPE => trigger::run::<SqsTrigger>(NoCliArgs, app, &loader).await?,
+                REDIS_TRIGGER_TYPE => trigger::run::<RedisTrigger>(NoCliArgs, app, loader).await?,
+                SQS_TRIGGER_TYPE => trigger::run::<SqsTrigger>(NoCliArgs, app, loader).await?,
                 COMMAND_TRIGGER_TYPE => {
                     let cli_args = trigger_command::CliArgs {
                         guest_args: ctx.args().to_vec(),
                     };
-                    trigger::run::<CommandTrigger>(cli_args, app, &loader).await?
+                    trigger::run::<CommandTrigger>(cli_args, app, loader).await?
                 }
                 MQTT_TRIGGER_TYPE => {
                     let cli_args = trigger_mqtt::CliArgs { test: false };
-                    trigger::run::<MqttTrigger>(cli_args, app, &loader).await?
+                    trigger::run::<MqttTrigger>(cli_args, app, loader).await?
                 }
                 _ => {
                     // This should never happen as we check for supported triggers in get_supported_triggers

--- a/containerd-shim-spin/src/source.rs
+++ b/containerd-shim-spin/src/source.rs
@@ -117,7 +117,7 @@ impl Source {
                 // TODO: This should be configurable, see https://github.com/deislabs/containerd-wasm-shims/issues/166
                 // TODO: ^^ Move aforementioned issue to this repo
                 let files_mount_strategy = FilesMountStrategy::Direct;
-                spin_loader::from_file(&source, files_mount_strategy, None).await
+                spin_loader::from_file(&source, files_mount_strategy, None, None).await
             }
             Source::OciSpin => {
                 let working_dir = PathBuf::from("/");

--- a/containerd-shim-spin/src/trigger.rs
+++ b/containerd-shim-spin/src/trigger.rs
@@ -28,7 +28,7 @@ pub(crate) const COMMAND_TRIGGER_TYPE: &str = <CommandTrigger as Trigger<Trigger
 pub(crate) async fn run<T>(
     cli_args: T::CliArgs,
     app: App,
-    loader: &ComponentLoader,
+    loader: &'static ComponentLoader,
 ) -> Result<BoxFuture<'static, Result<()>>>
 where
     T: Trigger<TriggerFactors> + 'static,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.92.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-wasip1", "wasm32-unknown-unknown"]
 profile = "default"

--- a/scripts/deploy-workloads.sh
+++ b/scripts/deploy-workloads.sh
@@ -24,7 +24,7 @@ update_mqtt_workload_with_broker_cluster_ip() {
 echo ">>> apply workloads"
 kubectl apply -f tests/workloads-common
 # wait for all the pods to be ready
-kubectl wait --for=condition=ready --timeout=120s pod --all
+kubectl wait --for=condition=ready --timeout=240s pod --all
 
 if [ "$1" == "workloads-pushed-using-spin-registry-push" ]; then
     update_mqtt_workload_with_broker_cluster_ip "tests/workloads-pushed-using-spin-registry-push"
@@ -44,7 +44,7 @@ else
 fi
 
 # wait for all the pods to be ready
-kubectl wait --for=condition=ready --timeout=120s pod --all
+kubectl wait --for=condition=ready --timeout=240s pod --all
 
 # get and describe all the pods
 echo ">>> Pods:"


### PR DESCRIPTION
Pins to a revision for Spin v4.0. Only other amendments were to ignore [build profiles](https://github.com/spinframework/spin/pull/3246) and configure a CLI format which is bogus in our case.