### PR TITLE
Create Runtime Class Manager Shim resources in releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,16 @@ jobs:
           mkdir -p _dist
           cp ./deployments/workloads/runtime.yaml _dist/runtime.yaml
           cp ./deployments/workloads/workload.yaml _dist/workload.yaml
-  
+
+      - name: Generate Runtime Class Manager Shim resource
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          ./scripts/generate-shim-resource.sh \
+            "${{ env.RELEASE_VERSION }}" \
+            "v1alpha1" \
+            "_artifacts" \
+            "_dist/runtime-class-manager-shim-v1alpha1-${{ env.RELEASE_VERSION }}.yaml"
+
       - name: Create release
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -57,6 +66,7 @@ jobs:
           gh release create ${{ env.RELEASE_VERSION }} \
             _dist/runtime.yaml#example-runtimes \
             _dist/workload.yaml#example-workloads \
+            _dist/runtime-class-manager-shim-v1alpha1-${{ env.RELEASE_VERSION }}.yaml#runtime-class-manager-shim
 
           for f in ./_artifacts/*/*.tar.gz; do gh release upload ${{ env.RELEASE_VERSION }} $f; done
 

--- a/scripts/generate-shim-resource.sh
+++ b/scripts/generate-shim-resource.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 # This script generates a Shim resource YAML for the Runtime Class Manager
-# Usage: ./generate-shim-resource.sh <release-version> <crd-version> <artifacts-dir> <output-file>
+# Usage: ./generate-shim-resource.sh <release-version> <crd-version> <artifacts-dir> <output-file> [crd-release-tag]
 
 RELEASE_VERSION="${1:?Release version required (e.g., v0.23.0)}"
 CRD_VERSION="${2:?CRD version required (e.g., v1alpha1)}"
 ARTIFACTS_DIR="${3:?Artifacts directory required}"
 OUTPUT_FILE="${4:?Output file required}"
+CRD_RELEASE_TAG="${5:-v0.2.0}"  # Default to v0.2.0 which contains v1alpha1 CRD
 
 # Calculate SHA256 checksums for the artifacts
 AARCH64_TARBALL="${ARTIFACTS_DIR}/containerd-shim-spin-v2-linux-aarch64/containerd-shim-spin-v2-linux-aarch64.tar.gz"
@@ -36,10 +37,10 @@ cat > "${OUTPUT_FILE}" <<EOF
 apiVersion: runtime.spinkube.dev/${CRD_VERSION}
 kind: Shim
 metadata:
-  name: spin-v2
+  name: spin
   labels:
-    app.kubernetes.io/name: spin-v2
-    app.kubernetes.io/instance: spin-v2
+    app.kubernetes.io/name: spin
+    app.kubernetes.io/instance: spin
     app.kubernetes.io/part-of: runtime-class-manager
 spec:
   nodeSelector:
@@ -68,10 +69,51 @@ spec:
     # Note: this name is used by the Spin Operator project as its default:
     # https://github.com/spinframework/spin-operator/blob/main/config/samples/spin-shim-executor.yaml
     name: wasmtime-spin-v2
-    handler: spin-v2
+    handler: spin
 
   rolloutStrategy:
     type: recreate
 EOF
 
 echo "Shim resource written to ${OUTPUT_FILE}"
+
+# Validate the generated Shim resource
+echo ""
+echo "Validating Shim resource..."
+
+# Check if kubectl-validate is installed
+if ! command -v kubectl-validate &> /dev/null; then
+    echo "kubectl-validate not found. Installing..."
+    if ! command -v go &> /dev/null; then
+        echo "Error: Go is required to install kubectl-validate but was not found" >&2
+        echo "Skipping validation. Please install Go or kubectl-validate manually." >&2
+        exit 1
+    fi
+    go install sigs.k8s.io/kubectl-validate@v0.0.4
+
+    # Add GOPATH/bin to PATH if not already there
+    if [[ -z "${GOPATH:-}" ]]; then
+        GOPATH=$(go env GOPATH)
+    fi
+    export PATH="${GOPATH}/bin:${PATH}"
+fi
+
+# Download the CRD schema to a temporary directory
+CRD_DIR=$(mktemp -d)
+CRD_FILE="${CRD_DIR}/runtime.spinkube.dev_shims.yaml"
+trap 'rm -rf ${CRD_DIR}' EXIT
+
+echo "Downloading CRD schema from runtime-class-manager ${CRD_RELEASE_TAG}..."
+if ! curl -fsSL -o "${CRD_FILE}" "https://raw.githubusercontent.com/spinframework/runtime-class-manager/refs/tags/${CRD_RELEASE_TAG}/config/crd/bases/runtime.spinkube.dev_shims.yaml"; then
+    echo "Error: Failed to download CRD schema from ${CRD_RELEASE_TAG}" >&2
+    exit 1
+fi
+
+# Validate the Shim resource
+echo "Running validation..."
+if kubectl-validate --local-crds "${CRD_DIR}" "${OUTPUT_FILE}"; then
+    echo "✓ Validation successful!"
+else
+    echo "✗ Validation failed!" >&2
+    exit 1
+fi

--- a/scripts/generate-shim-resource.sh
+++ b/scripts/generate-shim-resource.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script generates a Shim resource YAML for the Runtime Class Manager
+# Usage: ./generate-shim-resource.sh <release-version> <crd-version> <artifacts-dir> <output-file>
+
+RELEASE_VERSION="${1:?Release version required (e.g., v0.23.0)}"
+CRD_VERSION="${2:?CRD version required (e.g., v1alpha1)}"
+ARTIFACTS_DIR="${3:?Artifacts directory required}"
+OUTPUT_FILE="${4:?Output file required}"
+
+# Calculate SHA256 checksums for the artifacts
+AARCH64_TARBALL="${ARTIFACTS_DIR}/containerd-shim-spin-v2-linux-aarch64/containerd-shim-spin-v2-linux-aarch64.tar.gz"
+X86_64_TARBALL="${ARTIFACTS_DIR}/containerd-shim-spin-v2-linux-x86_64/containerd-shim-spin-v2-linux-x86_64.tar.gz"
+
+if [[ ! -f "${AARCH64_TARBALL}" ]]; then
+    echo "Error: aarch64 tarball not found at ${AARCH64_TARBALL}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${X86_64_TARBALL}" ]]; then
+    echo "Error: x86_64 tarball not found at ${X86_64_TARBALL}" >&2
+    exit 1
+fi
+
+AARCH64_SHA256=$(sha256sum "${AARCH64_TARBALL}" | awk '{print $1}')
+X86_64_SHA256=$(sha256sum "${X86_64_TARBALL}" | awk '{print $1}')
+
+echo "Generating Shim resource for ${RELEASE_VERSION} (CRD ${CRD_VERSION})"
+echo "  aarch64 SHA256: ${AARCH64_SHA256}"
+echo "  x86_64 SHA256: ${X86_64_SHA256}"
+
+# Generate the Shim YAML
+cat > "${OUTPUT_FILE}" <<EOF
+apiVersion: runtime.spinkube.dev/${CRD_VERSION}
+kind: Shim
+metadata:
+  name: spin-v2
+  labels:
+    app.kubernetes.io/name: spin-v2
+    app.kubernetes.io/instance: spin-v2
+    app.kubernetes.io/part-of: runtime-class-manager
+spec:
+  nodeSelector:
+    spin: "true"
+
+  fetchStrategy:
+    platforms:
+      - os: linux
+        arch: aarch64
+        location: "https://github.com/spinframework/containerd-shim-spin/releases/download/${RELEASE_VERSION}/containerd-shim-spin-v2-linux-aarch64.tar.gz"
+        sha256: "${AARCH64_SHA256}"
+      - os: linux
+        arch: x86_64
+        location: "https://github.com/spinframework/containerd-shim-spin/releases/download/${RELEASE_VERSION}/containerd-shim-spin-v2-linux-x86_64.tar.gz"
+        sha256: "${X86_64_SHA256}"
+
+  # Each runtime can provide a set of containerd runtime options to be set in the containerd
+  # configuration file.
+  containerdRuntimeOptions:
+    # The following option to pass cgroup driver information is available to runwasi based runtimes.
+    # For runwasi, the default cgroup driver is cgroupfs. Failure to configure the correct cgroup
+    # driver for runwasi shims may result in pod metrics failing to propagate accurately.
+    SystemdCgroup: "true"
+
+  runtimeClass:
+    # Note: this name is used by the Spin Operator project as its default:
+    # https://github.com/spinframework/spin-operator/blob/main/config/samples/spin-shim-executor.yaml
+    name: wasmtime-spin-v2
+    handler: spin-v2
+
+  rolloutStrategy:
+    type: recreate
+EOF
+
+echo "Shim resource written to ${OUTPUT_FILE}"


### PR DESCRIPTION
Currently, the RCM maintains a sample Spin shim: https://github.com/spinframework/runtime-class-manager/blob/main/config/samples/sample_shim_spin.yaml. It gets out of date easily. Instead of maintaining that file, this adds a Shim resource publication to releases. Then, RCM users can point to the release shim for the version of the Spin shim they want to install. Embeds the RCM Shim CRD versioning into file name for backwards compatibility.

Implemented with Claude Opus 4.6