### PR TITLE
Bump to containerd-shim-wasm 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,7 +1168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -1374,12 +1374,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1619,10 +1613,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
 
 [[package]]
-name = "containerd-client"
-version = "0.6.0"
+name = "const_format"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8bbfa492159a878a45bbd8fbd8d5a6fb2a4d6bd74836204a324523ba3233e0"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "containerd-client"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cc6911381d95039f381080ec148024d2bb0044a03363542b0a6b0b2c46592"
 dependencies = [
  "hyper-util",
  "prost 0.13.5",
@@ -1631,7 +1646,7 @@ dependencies = [
  "tokio",
  "tonic 0.12.3",
  "tonic-build",
- "tower 0.4.13",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -1649,7 +1664,7 @@ dependencies = [
  "log",
  "mio",
  "nix 0.29.0",
- "oci-spec",
+ "oci-spec 0.7.1",
  "os_pipe",
  "page_size",
  "prctl",
@@ -1694,7 +1709,7 @@ dependencies = [
  "ctrlc",
  "futures",
  "log",
- "oci-spec",
+ "oci-spec 0.9.0",
  "openssl",
  "serde_json",
  "spin-app",
@@ -1722,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d86b4754a7ca0b13a55dbab6836ae9abbc83f12d68ae0c9bbabab14edc58a28"
+checksum = "38357d0c7fdb42eea29ad99f1da2488c2a93ad3ca5d0e684121b34ca815c75c0"
 dependencies = [
  "anyhow",
  "caps",
@@ -1738,8 +1753,8 @@ dependencies = [
  "libcontainer",
  "log",
  "mio",
- "nix 0.29.0",
- "oci-spec",
+ "nix 0.31.3",
+ "oci-spec 0.9.0",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1749,16 +1764,16 @@ dependencies = [
  "tokio-stream",
  "trait-variant",
  "ttrpc-codegen",
- "wasmparser 0.228.0",
+ "wasmparser 0.231.0",
  "wat",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "containerd-shimkit"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50ce3653eadfd6a56ca25b59e8c6cbdbe4f8c215b26a3ef3af06c330c44d74a"
+checksum = "1f548b19bee283fec7d8763d904e52278da1982b760d8a83e5d282045dd25111"
 dependencies = [
  "anyhow",
  "caps",
@@ -1771,8 +1786,8 @@ dependencies = [
  "libcontainer",
  "log",
  "mio",
- "nix 0.29.0",
- "oci-spec",
+ "nix 0.31.3",
+ "oci-spec 0.9.0",
  "opentelemetry 0.23.0",
  "opentelemetry-otlp 0.16.0",
  "opentelemetry_sdk 0.23.0",
@@ -1791,7 +1806,7 @@ dependencies = [
  "tracing-subscriber",
  "trait-variant",
  "ttrpc-codegen",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "zygote",
 ]
 
@@ -2090,7 +2105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2105,7 +2120,7 @@ dependencies = [
  "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3628,7 +3643,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4090,6 +4105,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4115,19 +4145,20 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libcgroups"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f546e249532eae2595d93ebb2a2edc2e97462873b3277ee7238de83cee887"
+checksum = "ff828a1e0ab31b46ebefd1e8e231b7572dec6f663d17ecee1bee42a565649672"
 dependencies = [
  "fixedbitset 0.5.7",
- "nix 0.28.0",
- "oci-spec",
+ "nix 0.29.0",
+ "oci-spec 0.9.0",
+ "pathrs",
  "procfs",
  "serde",
  "thiserror 2.0.18",
@@ -4136,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "libcontainer"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c14f87246c3fe3819e0f1fd8483193e677ac190932bd5bb040c164763576a6d"
+checksum = "4c0d145abd052d4f374d5b9fb8beaa7c817a691ef0143260353b69761a96dd6a"
 dependencies = [
  "caps",
  "chrono",
@@ -4147,11 +4178,15 @@ dependencies = [
  "libcgroups",
  "libseccomp",
  "nc",
- "nix 0.28.0",
- "oci-spec",
- "once_cell",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "nix 0.29.0",
+ "oci-spec 0.9.0",
+ "pathrs",
  "prctl",
  "procfs",
+ "protobuf 3.2.0",
  "regex",
  "rust-criu",
  "safe-path",
@@ -4210,11 +4245,11 @@ dependencies = [
 
 [[package]]
 name = "libseccomp"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c57fd8981a80019807b7b68118618d29a87177c63d704fc96e6ecd003ae5b3"
+checksum = "0e5310a2c5b6ffbc094b5f70a2ca7b79ed36ad90e6f90994b166489a1bce3fcc"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "libc",
  "libseccomp-sys",
  "pkg-config",
@@ -4222,9 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "libseccomp-sys"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
+checksum = "60276e2d41bbb68b323e566047a1bfbf952050b157d8b5cdc74c07c1bf4ca3b6"
 
 [[package]]
 name = "libsql"
@@ -4531,9 +4566,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -4659,6 +4694,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea06a7cec15a9df94c58bddc472b1de04ca53bd32e72da7da2c5dd1c3885edc"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "nix"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,26 +4752,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if 1.0.4",
- "cfg_aliases 0.1.1",
- "libc",
- "memoffset 0.9.1",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -4717,19 +4771,19 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -4918,7 +4972,7 @@ dependencies = [
  "http-auth",
  "jwt 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.5.0",
- "oci-spec",
+ "oci-spec 0.7.1",
  "olpc-cjson",
  "regex",
  "reqwest 0.12.28",
@@ -4968,6 +5022,23 @@ dependencies = [
  "serde_json",
  "strum 0.26.3",
  "strum_macros 0.26.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder 0.20.2",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -5419,6 +5490,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pathrs"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb2311801201fc6fd2e8a9f4841b41eee565e992fbe713731e29e367b8e3f17"
+dependencies = [
+ "bitflags 2.11.0",
+ "itertools 0.14.0",
+ "libc",
+ "memchr",
+ "once_cell",
+ "rustix 1.1.3",
+ "rustversion",
+ "static_assertions",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pbjson"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5788,7 +5877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.31.2",
+ "nix 0.31.3",
 ]
 
 [[package]]
@@ -6202,13 +6291,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6242,10 +6331,10 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6420,7 +6509,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -6444,7 +6533,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tokio",
  "tokio-util",
  "url",
@@ -7560,7 +7649,7 @@ dependencies = [
  "anyhow",
  "conformance-tests",
  "log",
- "nix 0.31.2",
+ "nix 0.31.3",
  "test-environment",
 ]
 
@@ -7675,12 +7764,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8683,6 +8772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8705,6 +8800,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -9076,9 +9183,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -9086,7 +9193,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9109,9 +9216,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9148,7 +9255,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.2",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tokio",
  "tokio-util",
  "whoami",
@@ -10502,9 +10609,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.228.0"
+version = "0.231.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
+checksum = "b1ddaf0d6e069fcd98801b1bf030e3648897d9f09c45ac9ef566d068aca1b76f"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -11,7 +11,7 @@ Containerd shim for running Spin workloads.
 """
 
 [dependencies]
-containerd-shim-wasm = { version = "1.0.0", default-features = false, features = ["opentelemetry"]}
+containerd-shim-wasm = { version = "1.0.1", default-features = false, features = ["opentelemetry"]}
 log = "0.4"
 spin-app = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
 spin-componentize = { git = "https://github.com/spinframework/spin", tag = "v4.0.1" }
@@ -33,7 +33,7 @@ spin-factor-outbound-networking = { git = "https://github.com/spinframework/spin
 wasmtime = "44.0.0"
 openssl = { version = "*", features = ["vendored"] }
 anyhow = "1.0"
-oci-spec = "0.7"
+oci-spec = "0.9"
 futures = "0.3"
 ctrlc = { version = "3.5", features = ["termination"] }
 url = "2.3"

--- a/containerd-shim-spin/src/engine.rs
+++ b/containerd-shim-spin/src/engine.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, env, hash::Hash};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use containerd_shim_wasm::{
     sandbox::{
         context::{RuntimeContext, WasmLayer},
@@ -110,6 +110,24 @@ impl Sandbox for SpinSandbox {
     }
 }
 
+/// Returns true only when every wasm layer in `ctx` originates from the shim's
+/// local containerd precompile cache (indicated by `WasmLayer::precompiled == true`).
+/// AOT component loading must only be enabled when this is the case; otherwise
+/// attacker-supplied precompiled bytes from OCI image layers could be deserialized
+/// unsafely.
+fn layers_from_precompile_cache(ctx: &impl RuntimeContext) -> bool {
+    match ctx.entrypoint().source {
+        containerd_shim_wasm::sandbox::context::Source::Oci(layers) => {
+            let wasm_layers: Vec<_> = layers
+                .iter()
+                .filter(|l| is_wasm_content(l).is_some())
+                .collect();
+            !wasm_layers.is_empty() && wasm_layers.iter().all(|l| l.precompiled)
+        }
+        _ => false,
+    }
+}
+
 impl SpinSandbox {
     async fn wasm_exec_async(&self, ctx: &impl RuntimeContext) -> Result<()> {
         let cache = initialize_cache().await?;
@@ -149,14 +167,17 @@ impl SpinSandbox {
     ) -> Result<()> {
         let mut loader = spin_trigger::loader::ComponentLoader::default();
         match app_source {
-            Source::OciSpin | Source::OciWkg(_) => unsafe {
-                // Configure the loader to support loading AOT compiled components..
-                // Since all components were compiled by the shim (during `precompile`),
-                // this operation can be considered safe.
-                loader.enable_loading_aot_compiled_components();
-            },
-            // Currently, it is only possible to precompile applications distributed using
-            // `spin registry push`
+            Source::OciSpin | Source::OciWkg(_) => {
+                // Enable AOT only when every wasm layer originated from the shim's
+                // containerd precompile cache. If any layer came directly from an OCI
+                // image (precompiled: false), AOT loading is skipped so we never call
+                // unsafe deserialization on attacker-controlled bytes.
+                if layers_from_precompile_cache(ctx) {
+                    unsafe {
+                        loader.enable_loading_aot_compiled_components();
+                    }
+                }
+            }
             Source::File(_) => {}
         };
         // Box::leak gives a 'static reference. The loader lives for the process lifetime,
@@ -243,10 +264,24 @@ impl Compiler for SpinCompiler {
                         "Precompile called for wasm layer {:?}",
                         wasm_layer.config.digest()
                     );
-                    if wasmtime::Engine::detect_precompiled(&wasm_layer.layer).is_some() {
-                        log::info!("Layer already precompiled {:?}", wasm_layer.config.digest());
-                        Ok(Some(wasm_layer.layer))
+                    if wasm_layer.precompiled {
+                        // Layer came from the local containerd precompile cache — only
+                        // accept it if Wasmtime confirms the bytes are a valid artifact.
+                        if wasmtime::Engine::detect_precompiled(&wasm_layer.layer).is_some() {
+                            log::info!(
+                                "Layer already precompiled {:?}",
+                                wasm_layer.config.digest()
+                            );
+                            Ok(None)
+                        } else {
+                            bail!(
+                                "Layer is marked as precompiled but does not appear to be a valid precompiled component"
+                            )
+                        }
                     } else {
+                        // Layer came from an OCI image layer — always recompile from
+                        // WASM bytes, never trust precompiled-looking content from
+                        // untrusted image layers.
                         let component =
                             spin_componentize::componentize_if_necessary(&wasm_layer.layer)?;
                         let precompiled = self.0.precompile_component(&component)?;
@@ -277,9 +312,10 @@ mod tests {
             .serialize()
             .unwrap();
         let wasm_layers: Vec<WasmLayer> = vec![
-            // Needs to be precompiled
+            // Wasm module from OCI — needs compilation
             WasmLayer {
                 layer: module.clone(),
+                precompiled: false,
                 config: oci_spec::image::Descriptor::new(
                     MediaType::Other(constants::OCI_LAYER_MEDIA_TYPE_WASM.to_string()),
                     1024,
@@ -289,9 +325,10 @@ mod tests {
                     .unwrap(),
                 ),
             },
-            // Precompiled
+            // Already-compiled layer from the containerd precompile cache
             WasmLayer {
                 layer: component.to_owned(),
+                precompiled: true,
                 config: oci_spec::image::Descriptor::new(
                     MediaType::Other(constants::OCI_LAYER_MEDIA_TYPE_WASM.to_string()),
                     1024,
@@ -301,9 +338,10 @@ mod tests {
                     .unwrap(),
                 ),
             },
-            // Content that should be skipped
+            // Non-wasm data layer — should be skipped
             WasmLayer {
                 layer: vec![],
+                precompiled: false,
                 config: oci_spec::image::Descriptor::new(
                     MediaType::Other(spin_oci::client::DATA_MEDIATYPE.to_string()),
                     1024,
@@ -321,10 +359,47 @@ mod tests {
             .expect("compile failed");
         assert_eq!(precompiled.len(), 3);
         assert_ne!(precompiled[0].as_deref().expect("no first entry"), module);
-        assert_eq!(
-            precompiled[1].as_deref().expect("no second entry"),
-            component
-        );
+        // Cache layer: returned as None so the framework uses the already-compiled bytes
+        assert_eq!(precompiled[1], None);
         assert!(precompiled[2].is_none());
+    }
+
+    /// An OCI image layer containing valid precompiled
+    /// (native) bytes must be rejected rather than passed through to the AOT
+    /// loader. The `precompiled: false` flag signals "this came from an OCI
+    /// image, not from the trusted local cache."
+    #[tokio::test]
+    async fn precompile_rejects_oci_layer_with_precompiled_bytes() {
+        let wasmtime_engine = wasmtime::Engine::default();
+        // Produce real precompiled bytes using the same engine config
+        let compiled_bytes = wasmtime::component::Component::new(&wasmtime_engine, "(component)")
+            .unwrap()
+            .serialize()
+            .unwrap();
+
+        // Sanity-check: confirm these bytes actually look precompiled
+        assert!(wasmtime::Engine::detect_precompiled(&compiled_bytes).is_some());
+
+        // Simulate an OCI image whose wasm layer already contains precompiled bytes
+        let oci_layer = WasmLayer {
+            layer: compiled_bytes,
+            precompiled: false, // from OCI, not from cache
+            config: oci_spec::image::Descriptor::new(
+                MediaType::Other(constants::OCI_LAYER_MEDIA_TYPE_WASM.to_string()),
+                1024,
+                Digest::from_str(
+                    "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
+                )
+                .unwrap(),
+            ),
+        };
+
+        let compiler = SpinCompiler(wasmtime_engine);
+        let result = compiler.compile(&[oci_layer]).await;
+
+        assert!(
+            result.is_err(),
+            "OCI layer with precompiled bytes must not be trusted"
+        );
     }
 }

--- a/containerd-shim-spin/src/source.rs
+++ b/containerd-shim-spin/src/source.rs
@@ -169,6 +169,7 @@ mod tests {
     fn make_layer(media_type: &str, data: Vec<u8>) -> WasmLayer {
         WasmLayer {
             layer: data,
+            precompiled: false,
             config: Descriptor::new(
                 MediaType::Other(media_type.to_string()),
                 1024,

--- a/containerd-shim-spin/src/utils.rs
+++ b/containerd-shim-spin/src/utils.rs
@@ -141,6 +141,7 @@ mod tests {
     fn is_wasm_content_test() {
         let wasm_content = WasmLayer {
             layer: vec![],
+            precompiled: false,
             config: oci_spec::image::Descriptor::new(
                 MediaType::Other(constants::OCI_LAYER_MEDIA_TYPE_WASM.to_string()),
                 1024,
@@ -153,6 +154,7 @@ mod tests {
         // Should be ignored
         let data_content = WasmLayer {
             layer: vec![],
+            precompiled: false,
             config: oci_spec::image::Descriptor::new(
                 MediaType::Other(spin_oci::client::DATA_MEDIATYPE.to_string()),
                 1024,

--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -10,7 +10,13 @@ ENV CROSS_TOOLCHAIN_PREFIX=${CROSS_CMAKE_SYSTEM_PROCESSOR}-linux-musl-
 # libseccomp-rs requires a static musl-linked libseccomp; we compile it here
 # using the cross-rs musl toolchain so we don't depend on any third-party images.
 RUN apt-get -y update && \
-    apt-get install -y pkg-config protobuf-compiler gperf curl && \
+    apt-get install -y pkg-config gperf curl unzip && \
+    PROTOC_VERSION=25.3 && \
+    PROTOC_ARCH=$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/aarch_64/') && \
+    curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" \
+        -o /tmp/protoc.zip && \
+    unzip /tmp/protoc.zip -d /usr/local bin/protoc "include/*" && \
+    rm /tmp/protoc.zip && \
     curl -fsSL https://github.com/seccomp/libseccomp/releases/download/v2.5.3/libseccomp-2.5.3.tar.gz \
         -o /tmp/libseccomp.tar.gz && \
     tar xf /tmp/libseccomp.tar.gz -C /tmp && \


### PR DESCRIPTION
- Uses new `WasmLayer.precompiled` field to only accept precompiled artifacts that have been marked by `runwasi` as precompiled. Otherwise, re-precompiles the Wasm component.